### PR TITLE
Use a SQL file for DB setup

### DIFF
--- a/.github/workflows/init_db.sql
+++ b/.github/workflows/init_db.sql
@@ -1,0 +1,8 @@
+SELECT pg_catalog.set_config('search_path', '', false);
+
+-- sudo --user postgres createuser lea5 --createdb --pwprompt --echo
+CREATE ROLE lea5 PASSWORD 'lea5' NOSUPERUSER CREATEDB NOCREATEROLE INHERIT LOGIN;
+-- sudo --user postgres createdb lea5_development --owner=lea5 --echo
+CREATE DATABASE lea5_development OWNER lea5;
+-- sudo --user postgres createdb lea5_test --owner=lea5 --echo
+CREATE DATABASE lea5_test OWNER lea5;

--- a/.github/workflows/init_test_db.sh
+++ b/.github/workflows/init_test_db.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-sudo --user postgres psql -c "SELECT pg_catalog.set_config('search_path', '', false); CREATE ROLE lea5 PASSWORD 'lea5' NOSUPERUSER CREATEDB NOCREATEROLE INHERIT LOGIN;"
-sudo --user postgres createdb lea5_test --owner=lea5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           sudo sed --in-place '1 i\local lea5_test lea5 md5' /etc/postgresql/12/main/pg_hba.conf
           sudo systemctl restart postgresql.service
       - name: Create PostgreSQL user and database
-        run: ./.github/workflows/init_test_db.sh
+        run: sudo --user postgres psql --file ./.github/workflows/init_db.sql
       - name: Migrate database
         run: bundle exec rails db:migrate RAILS_ENV=test
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ It is recommended to use [rbenv][rbenv] and [nvm][nvm] to install both language 
 ## Development
 
 1. Install PostgreSQL
-2. Create a `lea5` user: `sudo --user postgres createuser lea5 --createdb --pwprompt`, and enter `lea5` as a password
-3. Create a development database: `sudo --user postgres createdb lea5_development --owner=lea5`
-4. Create a test database: `sudo --user postgres createdb lea5_test --owner=lea5`
-5. Clone the project
-6. Edit [`config/database.yml`](config/database.yml) if you chose a different password
+2. Initialize the database (users, databases) by running [`init_db.sql`](.github/workflows/init_db.sql): `sudo --user postgres psql --file ./.github/workflows/init_db.sql`
+3. Clone the project
+4. (Optional) Edit [`config/database.yml`](config/database.yml) if you chose a different password
 
 This README would normally document whatever steps are necessary to get the
 application up and running.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It is recommended to use [rbenv][rbenv] and [nvm][nvm] to install both language 
 ## Development
 
 1. Install PostgreSQL
-2. Initialize the database (users, databases) by running [`init_db.sql`](.github/workflows/init_db.sql): `sudo --user postgres psql --file ./.github/workflows/init_db.sql`
-3. Clone the project
+2. Clone the project
+3. Initialize the database (users, databases) by running [`init_db.sql`](.github/workflows/init_db.sql): `sudo --user postgres psql --file ./.github/workflows/init_db.sql`
 4. (Optional) Edit [`config/database.yml`](config/database.yml) if you chose a different password
 
 This README would normally document whatever steps are necessary to get the


### PR DESCRIPTION
This PR simplifies the Postgres test setup by using only SQL queries, instead of a mix of shell commands and SQL.
This will also be useful for local setup (we can reference it in the docs).