### PR TITLE
Use npm ci to install dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
             ${{ runner.os }}-node-
       - name: Install Node dependencies
-        run: npm install
+        run: npm ci
 
       - name: Configure PostgreSQL authentication
         run: |


### PR DESCRIPTION
Using `npm ci` instead of `npm install` is faster (npm doesn't need to rebuild the dependencies tree) and safer/stricter (it uses exactly what was specified in the package-lock.json)