### PR TITLE
Add Rake tasks to run system tests with FF, Chrome, headless or not

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           OVERCOMMIT_COLOR: "1"
 
       - name: Run RuboCop
-        run: bundle exec rubocop --parallel
+        run: bundle exec rubocop --parallel --format github
 
       - name: Configure PostgreSQL authentication
         run: |

--- a/README.md
+++ b/README.md
@@ -5,49 +5,75 @@
 
 ## Requirements
 
-- Ruby version 3.0.2 (see [.ruby-version](.ruby-version))
-- Node v16.6.2 (see [.nvmrc](.nvmrc))
-- Yarn v1
+- Ruby version 3.1.2 (see [.ruby-version](.ruby-version))
 - PostgreSQL 12.4+
 
-It is recommended to use [rbenv][rbenv] and [nvm][nvm] to install both language runtimes.
+It is recommended to use [rbenv][rbenv] to install a specific Ruby version.
 
 [rbenv]: https://github.com/rbenv/rbenv
-[nvm]: https://github.com/nvm-sh/nvm
 
 ## Development
 
-1. Install NodeJS and Ruby in the correct versions (run `rbenv version` and `nvm use` to check)
+1. Install Ruby with the correct version (run `rbenv version` to check)
 2. Install PostgreSQL
 3. Clone the project
-4. Install dependencies:
-   1. `bundle install`
-   2. `yarn install`
+4. Install dependencies with `bundle install`
 5. Initialize the database (users, databases) by running [`init_db.sql`](.github/workflows/init_db.sql): `sudo --user postgres psql < ./.github/workflows/init_db.sql`
 6. (Optional) Edit [`config/database.yml`](config/database.yml) if you chose a different password
 7. Install [Overcommit](https://github.com/sds/overcommit): `bundle exec overcommit --install`
 
 ## Tests
 
+The basic command to run tests is `rails test`.
+
+By default, "system" tests (end-to-end tests with a real browser) are not run with `rails test`. You need to
+run `rails test:system` to run them specifically, or `rails test:all`. System tests execute in a headless Chrome/Chromium
+browser (meaning the browser window will not appear), but you can select your browser of choice (Chrome, Firefox or
+Firefox Nightly) and configure the headless behaviour with the following commands:
+- `rails test:system:chrome`
+- `rails 'test:system:chrome[headless]'`
+- `rails test:system:firefox`
+- `rails 'test:system:firefox[headless]'`
+- `rails 'test:system:firefox[nightly]'`
+- `rails 'test:system:firefox[nightly,headless]'`
+
+Note that if you pass arguments to the rails tasks (using square brackets), you need to quote the entire task name or
+else your shell will probably try to expand the brackets (see the examples above).
+
+We use a bit of tooling around tests to help us and increase our confidence in our code:
 - [Minitest][minitest] and [minitest-reporters][minitest-reporters] are used to polish test outputs
-- [Guard][guard] is setup to run tests automatically on changes. You can start it with `bundle exec guard`
+- [Guard][guard] is set up to run tests automatically on changes. You can start it with `bundle exec guard`
 - Test coverage is done with [Simplecov][simplecov]. After running your tests, open `coverage/index.html` in the browser of your choice.
   For the tests to pass, there must be a minimum global coverage of 90% and 80% per branch and file.
 
 [minitest]: https://guides.rubyonrails.org/testing.html
-[minitest-reporters]: https://rubygems.org/gems/minitest-reporters/versions/1.1.11
+[minitest-reporters]: https://rubygems.org/gems/minitest-reporters
 [guard]: https://github.com/guard/guard
 [simplecov]: https://github.com/simplecov-ruby/simplecov
 
 ## Documentation
 
-See the [docs](docs/) folder for the documentation.
+See the [docs](docs) folder for the documentation.
 
 For now only the results of a [brainstorming session about our requirements][definition-des-besoins] is available.
 
 [<img alt="Requirements" src="docs/definition-des-besoins/Lea5-Definition-des-besoins.png" width="230" height="130">][definition-des-besoins]
 
 [definition-des-besoins]: docs/definition-des-besoins/README.md
+
+## Inspirations
+
+- Our original project [Lea4][lea4]. We had to move to Re2o when we became independent and needed to manage subscriptions.
+- [Re2o][re2o], which we used for 4 years. Unfortunately it does too much, and is too complex to configure, use and maintain.
+
+[lea4]: https://github.com/rezoleo/le4
+[re2o]: https://gitlab.federez.net/re2o/re2o
+
+## License
+
+[MIT](LICENSE)
+
+---
 
 This README would normally document whatever steps are necessary to get the
 application up and running.
@@ -71,15 +97,3 @@ Things you may want to cover:
 - Deployment instructions
 
 - ...
-
-## Inspirations
-
-- Our original project [Lea4][lea4]. We had to move to Re2o when we became independant and needed to manage subscriptions.
-- [Re2o][re2o], which we used for 4 years. Unfortunately it does too much, and is too complex to configure, use and maintain.
-
-[lea4]: https://github.com/rezoleo/le4/
-[re2o]: https://gitlab.federez.net/re2o/re2o
-
-## License
-
-[MIT](./LICENSE)

--- a/lib/tasks/system_test.rake
+++ b/lib/tasks/system_test.rake
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Inspired by https://nts.strzibny.name/rails-system-tests-headless/
+namespace :test do
+  namespace :system do
+    desc 'Run system tests with Chrome (can be run headless)'
+    # Syntax is task :task_name, [:list, :of, :params] => [:list, :of, :task, :dependencies]
+    # Parameters are positional, so calling `rails 'test:system:chrome[something]'` will define
+    # args.headless == 'something'
+    task :chrome, [:headless] => [:environment] do |_task, args|
+      ENV['DRIVER'] = if args.headless == 'headless'
+                        'headless_chrome'
+                      else
+                        'chrome'
+                      end
+      Rake::Task['test:system'].invoke
+    end
+
+    desc 'Run system tests with Firefox (can be run headless and/or use Firefox Nightly)'
+    task :firefox, %i[headless nightly] => [:environment] do |_task, args|
+      # Small (ab)use of args.to_a, normally used to retrieve a variable number of arguments
+      # Since here we only care that the *strings* 'headless' or 'nightly' are passed, we convert
+      # the args struct to an array of all argument values, then just check if a specific string is in it.
+      # That way we can run 'test:system:firefox[nightly,headless]' or 'test:system:firefox[headless,nightly]',
+      # with whichever order or combination or arguments.
+      # See https://ruby.github.io/rake/doc/rakefile_rdoc.html#label-Tasks+that+take+Variable-length+Parameters
+      # @type [Array<String>] args_list
+      args_list = args.to_a
+      ENV['DRIVER'] = if args_list.include? 'headless'
+                        'headless_firefox'
+                      else
+                        'firefox'
+                      end
+      ENV['DRIVER_BINARY'] = 'firefox-nightly' if args_list.include? 'nightly'
+      Rake::Task['test:system'].invoke
+    end
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,6 +3,21 @@
 require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  # Inspired by https://nts.strzibny.name/rails-system-tests-headless/
+  DRIVER = if ENV['DRIVER']
+             ENV['DRIVER'].to_sym
+           else
+             :headless_chrome
+           end
+
+  # To pass options to the underlying driver, we need to use a block like so:
+  # driven_by ..., |driver_option| do
+  #   driver_option.something
+  # end
+  # https://rubydoc.info/gems/actionpack/7.0.4/ActionDispatch/SystemTestCase
+  driven_by :selenium, using: DRIVER, screen_size: [1400, 1400] do |driver_option|
+    # https://www.selenium.dev/documentation/webdriver/browsers/firefox/#start-browser-in-a-specified-location
+    driver_option.binary = ENV['DRIVER_BINARY'] if ENV['DRIVER_BINARY']
+  end
   Capybara.enable_aria_label = true
 end


### PR DESCRIPTION
This PR allows you to run system tests using your browser of choice.

It adds two rake commands:
  - `rails test:system:chrome`
  - `rails test:system:firefox`

You can pass the argument `[headless]` to each of them to run tests headless.
The `test:system:firefox` task also supports `[nightly]` argument, to use Firefox Nightly.

Note that depending on your shell (e.g. in ZSH) you need to quote the entire argument *or* escape the square brackets, like so:
`rails test:system:firefox\[headless,nightly\]` or `rails 'test:system:chrome[headless]'` (else ZSH tries to expand the brackets into something else).

The default `rails test:system` command behaviour was not changed and still runs Chrome headless.
