### PR TITLE
Update the CI rules

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -52,7 +52,7 @@ CommitMsg:
     description: 'Ensure commit message follows commit style'
     on_fail: warn
     pattern: '^(build|ci|docs|feat|fix|perf|refactor|style|test)(\(.+\))?: .{1,50}'
-    expected_pattern_message: '<build|ci|docsfeat|fix|perf|refactor|style|test>(<scope>): <message>'
+    expected_pattern_message: '<build|ci|docs|feat|fix|perf|refactor|style|test>(<scope>): <message>'
     sample_message: 'ci(rubocop): increase class length limit'
 
 PrePush:

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -43,6 +43,18 @@ PreCommit:
 #    exclude:
 #      - '**/db/structure.sql' # Ignore trailing whitespace in generated files
 
+CommitMsg:
+  CapitalizedSubject:
+    enabled: false
+
+  MessageFormat:
+    enabled: true
+    description: 'Ensure commit message follows commit style'
+    on_fail: warn
+    pattern: '^(build|ci|docs|feat|fix|perf|refactor|style|test)(\(.+\))?: .{1,50}'
+    expected_pattern_message: '<build|ci|docsfeat|fix|perf|refactor|style|test>(<scope>): <message>'
+    sample_message: 'ci(rubocop): increase class length limit'
+
 PrePush:
   Brakeman:
     enabled: true

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -55,6 +55,9 @@ CommitMsg:
     expected_pattern_message: '<build|ci|docs|feat|fix|perf|refactor|style|test>(<scope>): <message>'
     sample_message: 'ci(rubocop): increase class length limit'
 
+  TextWidth:
+    max_subject_width: 80
+
 PrePush:
   Brakeman:
     enabled: true

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -56,6 +56,7 @@ CommitMsg:
     sample_message: 'ci(rubocop): increase class length limit'
 
   TextWidth:
+    enabled: true
     max_subject_width: 80
 
 PrePush:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ Layout/FirstArrayElementIndentation:
 
 Metrics/ClassLength:
   Enabled: true
+  Max: 200
   Exclude:
     - test/**/*
 
@@ -31,7 +32,7 @@ Minitest/EmptyLineBeforeAssertionMethods:
   Enabled: false
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
 
 Metrics/AbcSize:
   Max: 20


### PR DESCRIPTION
Proposition de mise à jour des règles des différents hooks mais aussi de rubocop :
- Augmentation de la longueur maximale d'une classe de 100 à 200 lignes
- Augmentation de la longueur maximale d'une méthode de 15 à 20 lignes
- Suppression de la majuscule obligatoire en début de commit (bien que non bloquante)
- Ajout d'un format de message de commit selon le workflow d'AngularJS (non bloquant)
- Augmentation de la taille maximale du titres des commit de 60 à 80 caractères (non bloquant)