### PR TITLE
test: fix flaky system/end-to-end tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,6 +81,10 @@ module ActiveSupport
         delete logout_path
       elsif is_a? ApplicationSystemTestCase
         click_on 'Logout'
+        # `click_on` doesn't wait for whatever is run by the click to end,
+        # so we wait until the 'Login' button is visible (<=> we went through
+        # the logout process).
+        find_button 'Login'
       end
     end
 
@@ -91,8 +95,12 @@ module ActiveSupport
       if is_a? ActionDispatch::IntegrationTest
         get auth_callback_path
       elsif is_a? ApplicationSystemTestCase
-        visit users_path # We must first visit a page to click on the button
+        visit root_path # We must first visit a page to click on the button
         click_on 'Login'
+        # `click_on` doesn't wait for whatever is run by the click to end,
+        # so we wait until the 'Logout' button is visible (<=> we went through
+        # the login process).
+        find_button 'Logout'
       end
     end
   end


### PR DESCRIPTION
System tests (or end-to-end tests, run with a real browser using Capybara) were flaky, in that they sometimes failed with a "You do not have permission to see this page", despite the login process in the tests setup. This flakiness was reduced the more tests were run in parallel, explaining how I never saw it locally but it happened sometimes in CI.
What was apparent from the test logs was that the root page was viewed, then the page under the test, and finally the login/keycloak page, even though the `sign_in` helper does `visit root_page; click_on 'Login'`. The cause was that Capybara doesn't wait for the result of the click to complete (how would it know what it's supposed to trigger? navigation, AJAX?) and lets the test continue immediately.
Adding a `find_*` call right after tells Capybara to wait until the following element is visible in the page (or fail after a timeout), effectively waiting for the login process to happen.