### PR TITLE
test: measure code coverage for test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,15 +48,11 @@ jobs:
           RAILS_ENV: test
         run: bin/rails db:test:prepare
 
-      - name: Run tests
+      - name: Run all tests, including system (end-to-end) tests
+        id: tests
         env:
           RAILS_ENV: test
         run: bin/rails test:all
-
-      - name: Run system (end-to-end) tests
-        env:
-          RAILS_ENV: test
-        run: bin/rails test:system
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -65,7 +61,7 @@ jobs:
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: failure() && steps.tests.conclusion == 'failure'
         with:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+SimpleCov.start 'rails' do
+  enable_coverage :branch
+
+  # TODO: Enable this after merging Ruby updates and adding tests to increase coverage
+  # enable_coverage_for_eval
+  # track_files 'app/views/**/*.erb'
+  # add_group 'Views', 'app/views'
+
+  add_group 'Services', 'app/services/'
+  add_group 'API', 'app/controllers/api/'
+  add_group 'CanCanCan Abilities', 'app/abilities/'
+
+  # Loading SimpleCov as early as in the `bin/rails` file makes the Rakefile appear
+  # in the coverage, and we don't need it.
+  add_filter 'Rakefile'
+
+  # Ensure 100% "code coverage" on test files, to make sure they are actually run
+  # (if a test file name doesn't end with _test.rb it will be silently ignored)
+  # Simplecov adds default filters to ignore test folders, we need to remove them
+  # https://github.com/simplecov-ruby/simplecov/blob/main/lib/simplecov/profiles/rails.rb#L4
+  # https://github.com/simplecov-ruby/simplecov/blob/main/lib/simplecov/profiles/test_frameworks.rb
+  # https://github.com/simplecov-ruby/simplecov/issues/816
+  # https://github.com/simplecov-ruby/simplecov/issues/803
+  test_folders = Set['/test/', '/features/', '/spec/', '/autotest/']
+  filters.delete_if do |f|
+    f.is_a?(SimpleCov::StringFilter) && test_folders.include?(f.filter_argument)
+  end
+
+  track_files 'test/**/*.rb'
+  add_group 'Tests', 'test/'
+
+  # Add a tab in SimpleCov HTML report with ignored lines
+  # Source: https://github.com/simplecov-ruby/simplecov/issues/312
+  add_group 'Ignored Code' do |src_file|
+    File.readlines(src_file.filename).grep(/#{SimpleCov.nocov_token}/).any?
+  end
+
+  if ENV['CI']
+    require 'simplecov-cobertura'
+    formatter SimpleCov::Formatter::CoberturaFormatter
+  else
+    formatter SimpleCov::Formatter::HTMLFormatter
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :test do
   gem 'minitest-reporters', '~> 1.7'
   gem 'rails-controller-testing', '~> 1.0'
   gem 'selenium-webdriver'
-  gem 'simplecov', '~> 0.22.0'
-  gem 'simplecov-cobertura', '~> 2.1'
+  gem 'simplecov', '~> 0.22.0', require: false
+  gem 'simplecov-cobertura', '~> 2.1', require: false
   gem 'webmock', '~> 3.23'
 end

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,18 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
+
+# Load Simplecov as early as possible, to ensure code coverage is correctly generated.
+# Rails discovers all test/**/*_test.rb files and loads them in order, this in turn loads
+# test_helper.rb, which finally requires simplecov.
+# However, at that point it is too late, as the first test has been required and its
+# coverage cannot be extracted.
+# By requiring simplecov just as we run the `rails test` command, we can instrument Ruby
+# before the first test is even loaded.
+# Inspired by https://github.com/simplecov-ruby/simplecov#getting-started where they suggest
+# editing `bin/rails`.
+if ARGV[0] == 't' || ARGV[0] == 'test' || ARGV[0]&.start_with?('test:')
+  require 'simplecov'
+end
+
 require "rails/commands"

--- a/lib/tasks/system_test.rake
+++ b/lib/tasks/system_test.rake
@@ -8,12 +8,14 @@ namespace :test do
     # Parameters are positional, so calling `rails 'test:system:chrome[something]'` will define
     # args.headless == 'something'
     task :chrome, [:headless] => [:environment] do |_task, args|
+      # :nocov:
       ENV['DRIVER'] = if args.headless == 'headless'
                         'headless_chrome'
                       else
                         'chrome'
                       end
       Rake::Task['test:system'].invoke
+      # :nocov:
     end
 
     desc 'Run system tests with Firefox (can be run headless and/or use Firefox Nightly)'
@@ -25,6 +27,7 @@ namespace :test do
       # with whichever order or combination or arguments.
       # See https://ruby.github.io/rake/doc/rakefile_rdoc.html#label-Tasks+that+take+Variable-length+Parameters
       # @type [Array<String>] args_list
+      # :nocov:
       args_list = args.to_a
       ENV['DRIVER'] = if args_list.include? 'headless'
                         'headless_firefox'
@@ -33,6 +36,7 @@ namespace :test do
                       end
       ENV['DRIVER_BINARY'] = 'firefox-nightly' if args_list.include? 'nightly'
       Rake::Task['test:system'].invoke
+      # :nocov:
     end
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,17 +4,20 @@ require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Inspired by https://nts.strzibny.name/rails-system-tests-headless/
+  # :nocov:
   DRIVER = if ENV['DRIVER']
              ENV['DRIVER'].to_sym
            else
              :headless_chrome
            end
+  # :nocov:
 
   # To pass options to the underlying driver, we need to use a block like so:
   # driven_by ..., |driver_option| do
   #   driver_option.something
   # end
   # https://rubydoc.info/gems/actionpack/7.0.4/ActionDispatch/SystemTestCase
+  # :nocov:
   if ENV['CAPYBARA_SERVER_PORT']
     served_by host: 'rails-app', port: ENV['CAPYBARA_SERVER_PORT']
 
@@ -22,12 +25,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       browser: :remote,
       url: "http://#{ENV.fetch('SELENIUM_HOST')}:4444"
     }
+    # :nocov:
   else
     capybara_options = {}
   end
   driven_by :selenium, using: DRIVER, screen_size: [1400, 1400], options: capybara_options do |driver_option|
     # https://www.selenium.dev/documentation/webdriver/browsers/firefox/#start-browser-in-a-specified-location
+    # :nocov:
     driver_option.binary = ENV['DRIVER_BINARY'] if ENV['DRIVER_BINARY']
+    # :nocov:
   end
 
   Capybara.enable_aria_label = true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,27 +1,8 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start 'rails' do
-  enable_coverage :branch
-
-  # TODO: Enable this after merging Ruby updates and adding tests to increase coverage
-  # enable_coverage_for_eval
-  # track_files 'app/views/**/*.erb'
-  # add_group 'Views', 'app/views'
-
-  # Add a tab in SimpleCov HTML report with ignored lines
-  # Source: https://github.com/simplecov-ruby/simplecov/issues/312
-  add_group 'Ignored Code' do |src_file|
-    File.readlines(src_file.filename).grep(/#{SimpleCov.nocov_token}/).any?
-  end
-
-  if ENV['CI']
-    require 'simplecov-cobertura'
-    formatter SimpleCov::Formatter::CoberturaFormatter
-  else
-    formatter SimpleCov::Formatter::HTMLFormatter
-  end
-end
+# SimpleCov configuration was moved to `.simplecov`
+# https://github.com/simplecov-ruby/simplecov#using-simplecov-for-centralized-config
 
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'


### PR DESCRIPTION
Code coverage is usually seen as the parts of your application code that are covered by tests. A higher percentage is *one* *indicator* of a safer application, as more code has been run during the tests. It is *not* a perfect indicator nor a number that *must* be at 100%, as those tests could be testing the wrong thing, or nothing at all, or mocking all important parts and just testing an empty shell...

However, adding code coverage to the tests themselves and ensuring it stays at 100% is interesting. While some parts of the app could be written "just in case" or be too complex to test, if you have written a test: you must mean it! Making sure that all code under the "test" folder has been run is a simple way to avoid mistakes, such as a test file not named `*_test.rb` that will not be found by Rails test runner (happened in [c83f0ef9dc4f9bea78a126443701afa9a3d6fa03][1]), a loop that should test multiple things but looping over an empty set so it doesn't test anything (e.g. you query models and check an attribute on each, but the query is wrong)...
[An interesting video by Anthony Sottile on the topic][2].

This commit also moves the SimpleCov configuration from the `test_helper.rb` to its own `.simplecov` file, which ensures it is configured only once even in parallel tests or with multiple frameworks.

[1]: https://github.com/rezoleo/lea5/pull/441/files#diff-1cba8981fca6b8913a8746b7ab404d7110f86cf99448b8076bd0ca1e2d79ea6f
[2]: https://www.youtube.com/watch?v=70T6OxKwxm0