### PR TITLE
chore: send test results to Codecov Test Analytics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,11 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@v1
+        if: ${{ !cancelled() }}
+        with:
+          use_oidc: true
+          disable_search: true
+          files: ./test/reports/TEST-*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Custom ignore rules
 /doc
 /.yardoc
+/test/reports/TEST-*.xml
 
 # See https://help.github.com/articles/ignoring-files for more about ignoring files.
 #

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,16 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 require 'minitest/reporters'
-Minitest::Reporters.use! unless ENV['RM_INFO']
+# :nocov:
+if ENV['CI']
+  Minitest::Reporters.use! [
+    Minitest::Reporters::DefaultReporter.new(color: true),
+    Minitest::Reporters::JUnitReporter.new
+  ]
+else
+  Minitest::Reporters.use! unless ENV['RM_INFO']
+end
+# :nocov:
 
 require 'webmock/minitest'
 WebMock.disable_net_connect!(


### PR DESCRIPTION
Use the new Codecov feature for Test Analytics:
> Test Analytics is a new set of features from Codecov that provides insights into the health of your test framework. It provides you with:
> 1. An overview of test run times and failure rates for all tests across main and feature branches
> 2. A list of tests that your PR failed as a PR comment, along with a stack trace : enabling easier debugging
> 3. A list of failed tests that are known to be flaky on main, that your PR failed, as a PR comment : enabling quicker retry and resolution.

https://docs.codecov.com/docs/test-analytics

This PR adds the JUnit Minitest reporter in CI in addition to the Default reporter, so we have the `........` in GitHub Actions to see the progress and we have the XML ready to be used by Codecov.