### PR TITLE
chore: add a script to fix PostgreSQL collation version warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ For now only the results of a [brainstorming session about our requirements][def
 
 [definition-des-besoins]: docs/definition-des-besoins/README.md
 
+## Tips
+
+If you get the following errors from PostgreSQL after upgrading `glibc` or `icu`,
+you can run [`bin/reindex-db-after-collation-upgrade`](./bin/reindex-db-after-collation-upgrade)
+```
+WARNING:  database "postgres" has a collation version mismatch
+DETAIL:  The database was created using collation version X.YY, but the operating system provides version X.ZZ.
+HINT:  Rebuild all objects in this database that use the default collation and run ALTER DATABASE postgres REFRESH COLLATION VERSION,
+or build PostgreSQL with the right library version.
+```
+
 ## Inspirations
 
 - Our original project [Lea4][lea4]. We had to move to Re2o when we became independent and needed to manage subscriptions.

--- a/bin/reindex-db-after-collation-upgrade
+++ b/bin/reindex-db-after-collation-upgrade
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This script can be used after an upgrade to glibc or icu causes PostgreSQL
+# to throw this kind of errors:
+#   WARNING:  database "postgres" has a collation version mismatch
+#   DETAIL:  The database was created using collation version X.YY, but the operating system provides version X.ZZ.
+#   HINT:  Rebuild all objects in this database that use the default collation and run ALTER DATABASE postgres REFRESH COLLATION VERSION,
+#   or build PostgreSQL with the right library version.
+#
+# This will reindex all Lea5 databases (lea5_test-*, lea5_development, lea5_production) as well as template1,
+# and update the collation version used for the database.
+# Source: https://wiki.archlinux.org/title/PostgreSQL#WARNING:_database_%22postgres%22_has_a_collation_version_mismatch
+
+lea5_tables=$(sudo -u postgres psql --quiet --tuples-only --command="SELECT datname FROM pg_database WHERE datname LIKE 'lea5_%';" | sort --version-sort)
+
+echo "Reindexing template1..."
+sudo -u postgres reindexdb --dbname=template1 \
+  && sudo -u postgres psql -c "ALTER DATABASE \"template1\" REFRESH COLLATION VERSION;"
+
+for table in ${lea5_tables}; do
+  echo "Reindexing ${table}"
+  sudo -u postgres reindexdb --dbname="${table}" \
+    && sudo -u postgres psql -c "ALTER DATABASE \"${table}\" REFRESH COLLATION VERSION;"
+done


### PR DESCRIPTION
This script can be used after an upgrade to `glibc` or `icu` causes PostgreSQL to throw this kind of errors:
```
WARNING:  database "postgres" has a collation version mismatch
DETAIL:  The database was created using collation version X.YY, but the operating system provides version X.ZZ.
HINT:  Rebuild all objects in this database that use the default collation and run ALTER DATABASE postgres REFRESH COLLATION VERSION,
or build PostgreSQL with the right library version.
```

This will reindex all Lea5 databases (`lea5_test-*`, `lea5_development`, `lea5_production`) as well as `template1`, and update the collation version used for the database.

Source: https://wiki.archlinux.org/title/PostgreSQL#WARNING:_database_%22postgres%22_has_a_collation_version_mismatch 