### PR TITLE
feat: replacing default_scope with the sellable scope

### DIFF
--- a/app/controllers/sales_controller.rb
+++ b/app/controllers/sales_controller.rb
@@ -7,7 +7,7 @@ class SalesController < ApplicationController
     @sale = @owner.sales_as_client.new
     authorize! :new, @sale
 
-    @articles = Article.all
+    @articles = Article.sellable.all
     @subscription_offers = SubscriptionOffer.order(duration: :desc)
     @payment_methods = PaymentMethod.all
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -11,7 +11,7 @@ class Article < ApplicationRecord
                     numericality: { greater_than: 0, only_integer: true, message: 'Must be a positive
                      number. Maximum 2 numbers after comma' }
 
-  default_scope { where(deleted_at: nil) }
+  scope :sellable, -> { where(deleted_at: nil) }
 
   def soft_delete
     update(deleted_at: Time.zone.now) if deleted_at.nil?

--- a/app/models/sale.rb
+++ b/app/models/sale.rb
@@ -107,7 +107,7 @@ class Sale < ApplicationRecord
     def generate_sales_subscription_offers(duration)
       return [] if duration <= 0
 
-      subscription_offers = SubscriptionOffer.order(duration: :desc)
+      subscription_offers = SubscriptionOffer.sellable.order(duration: :desc)
       sales_subscription_offers = []
       subscription_offers.each do |offer|
         break if duration == 0

--- a/app/models/subscription_offer.rb
+++ b/app/models/subscription_offer.rb
@@ -12,7 +12,7 @@ class SubscriptionOffer < ApplicationRecord
                     numericality: { greater_than: 0, only_integer: true, message: 'Must be a positive
                      number. Maximum 2 numbers after comma' }
 
-  default_scope { where(deleted_at: nil) }
+  scope :sellable, -> { where(deleted_at: nil) }
 
   def soft_delete
     update(deleted_at: Time.zone.now) if deleted_at.nil?

--- a/test/controllers/admin/subscription_offers_controller_test.rb
+++ b/test/controllers/admin/subscription_offers_controller_test.rb
@@ -17,14 +17,14 @@ module Admin
     end
 
     test 'should create offer' do
-      assert_difference 'SubscriptionOffer.unscoped.count', 1 do
+      assert_difference 'SubscriptionOffer.count', 1 do
         post subscription_offers_path, params: { subscription_offer: { duration: 10, price: 1456 } }
       end
       assert_redirected_to admin_path
     end
 
     test 'should re-render if missing offer information' do
-      assert_no_difference 'SubscriptionOffer.unscoped.count' do
+      assert_no_difference 'SubscriptionOffer.count' do
         post subscription_offers_path, params: { subscription_offer: { duration: nil } }
       end
 
@@ -32,7 +32,7 @@ module Admin
     end
 
     test 'should soft_delete offer' do
-      assert_no_difference 'SubscriptionOffer.unscoped.count' do
+      assert_no_difference 'SubscriptionOffer.count' do
         delete subscription_offer_path(@subscription_offer)
       end
       assert_redirected_to admin_path
@@ -40,7 +40,7 @@ module Admin
 
     test 'should hard_delete offer' do
       offer = SubscriptionOffer.create!(duration: 1, price: 500)
-      assert_difference 'SubscriptionOffer.unscoped.count', -1 do
+      assert_difference 'SubscriptionOffer.count', -1 do
         delete subscription_offer_path(offer)
       end
       assert_redirected_to admin_path

--- a/test/controllers/sales_controller_test.rb
+++ b/test/controllers/sales_controller_test.rb
@@ -26,6 +26,14 @@ class SalesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'form'
   end
 
+  test 'should only list sellable articles' do
+    get new_user_sale_path(user_id: @user.id)
+    assert_response :success
+    assert_template 'sales/new'
+    assert_select 'form'
+    assert_dom 'template select option', Article.sellable.count + 1 # to account for "Select an article"
+  end
+
   test 'should create sale and redirect if sale is valid' do
     assert_difference 'Sale.count', 1 do
       post user_sales_path(user_id: @user.id, format: :html), params: { sale: @sale_params }

--- a/test/fixtures/subscription_offers.yml
+++ b/test/fixtures/subscription_offers.yml
@@ -7,3 +7,18 @@ month:
 year:
   duration: 12
   price: 5000
+
+2_months:
+  duration: 2
+  price: 1600
+  deleted_at: 2025-01-01 00:00:00
+
+month_old:
+  duration: 1
+  price: 800
+  deleted_at: 2025-01-01 00:00:00
+
+year_old:
+  duration: 12
+  price: 8000
+  deleted_at: 2025-01-01 00:00:00

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -66,4 +66,8 @@ class ArticleTest < ActiveSupport::TestCase
     assert_predicate @article, :persisted?
     assert_includes @article.errors[:base], 'Cannot delete record because dependent articles sales exist'
   end
+
+  test 'only available articles should be sellable' do
+    assert_equal 2, Article.sellable.count
+  end
 end

--- a/test/models/subscription_offer_test.rb
+++ b/test/models/subscription_offer_test.rb
@@ -50,10 +50,14 @@ class SubscriptionOfferTest < ActiveSupport::TestCase
 
   test 'offer should soft delete' do
     @subscription_offer.deleted_at = nil
-    assert_no_difference 'SubscriptionOffer.unscoped.count' do
+    assert_no_difference 'SubscriptionOffer.count' do
       @subscription_offer.soft_delete
     end
     assert_not_nil @subscription_offer.deleted_at
+  end
+
+  test 'only available subscriptions should be sellable' do
+    assert_equal 2, SubscriptionOffer.sellable.count
   end
 
   test 'soft_delete should not change deleted_at date' do
@@ -66,13 +70,13 @@ class SubscriptionOfferTest < ActiveSupport::TestCase
   test 'offer should be destroyed if no sales' do
     @subscription_offer.sales.destroy_all
     @subscription_offer.refunds.destroy_all
-    assert_difference 'SubscriptionOffer.unscoped.count', -1 do
+    assert_difference 'SubscriptionOffer.count', -1 do
       assert_predicate @subscription_offer, :destroy
     end
   end
 
   test 'offer should not destroy if dependant' do
-    assert_no_difference 'SubscriptionOffer.unscoped.count' do
+    assert_no_difference 'SubscriptionOffer.count' do
       assert_not_predicate @subscription_offer, :destroy
     end
 


### PR DESCRIPTION
Added a "sellable" attribute to articles to ensure that a product is not deleted.
Added new tests to verify that only sellable articles are available.
fixes https://github.com/rezoleo/lea5/issues/480
