### PR TITLE
feat(refunds): rework schema and implement refund handling

### DIFF
--- a/app/abilities/user_ability.rb
+++ b/app/abilities/user_ability.rb
@@ -15,9 +15,10 @@ class UserAbility
 
     can [:read], Subscription, user: user
     can [:read], Sale, client: user
-    can [:read], Refund, user: user
+    can [:read], Refund, sale: { client: user }
     can [:read], FreeAccess, user: user
     can [:read], Invoice, sale: { client: user }
+    can [:read], Invoice, refund: { sale: { client: user } }
 
     return unless user.admin?
 

--- a/app/controllers/refunds_controller.rb
+++ b/app/controllers/refunds_controller.rb
@@ -1,4 +1,48 @@
 # frozen_string_literal: true
 
 class RefundsController < ApplicationController
+  before_action :sale, only: [:new, :create]
+
+  def new
+    authorize! :create, Refund
+    @refund = Refund.new(sale: @sale)
+    load_form_data
+  end
+
+  def create
+    authorize! :create, Refund
+    @refund = Refund.create_with_credit_note(
+      sale: @sale,
+      refund_method: PaymentMethod.find_by(id: refund_params[:refund_method_id]),
+      refunder: current_user,
+      refund_scope: {
+        article_ids: refund_params[:article_ids] || [],
+        refund_subscription: ActiveModel::Type::Boolean.new.cast(refund_params[:refund_subscription])
+      }
+    )
+
+    if @refund.persisted?
+      flash[:success] = 'Refund created!'
+      redirect_to @sale.client
+    else
+      load_form_data
+      render 'new', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def sale
+    @sale = Sale.find(params[:sale_id])
+  end
+
+  def load_form_data
+    @refundable_article_sales = @sale.refundable_article_sales.includes(:article)
+    @subscription = @sale.subscription
+    @refund_methods = PaymentMethod.all
+  end
+
+  def refund_params
+    params.require(:refund).permit(:refund_method_id, :refund_subscription, article_ids: [])
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,9 @@ class UsersController < ApplicationController
     @machines = @user.machines.includes(:ip).order(created_at: :asc)
     @subscriptions = @user.subscriptions.order(created_at: :desc)
     @free_accesses = @user.free_accesses.order(created_at: :desc)
-    @sales = @user.sales_as_client.order(created_at: :desc)
+    @sales = @user.sales_as_client
+                  .includes(refunds: [:invoice, { articles_refunds: :article }])
+                  .order(created_at: :desc)
   end
 
   def new

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-# It is recommended to instantiate a new invoice from a sale, using {Invoice.build_from_sale}
+# It is recommended to instantiate a new invoice from a sale, using {Invoice.build_from_sale},
+# or from a refund, using {Invoice.build_from_refund}.
 class Invoice < ApplicationRecord
   has_one :sale, dependent: :restrict_with_exception
+  has_one :refund, dependent: :restrict_with_exception
   has_one_attached :pdf
 
   validates :number, presence: true, uniqueness: true
@@ -10,9 +12,9 @@ class Invoice < ApplicationRecord
   before_validation :assign_number!
   after_create_commit :generate_pdf!
 
-  # @return [User]
+  # @return [User] the client this invoice (or credit note) concerns
   def user
-    sale.client
+    (sale || refund&.sale).client
   end
 
   def to_param
@@ -23,6 +25,17 @@ class Invoice < ApplicationRecord
   # @return [Invoice]
   def self.build_from_sale(sale)
     generation_json = generate_hash(sale)
+
+    new do |invoice|
+      invoice.generation_json = generation_json
+    end
+  end
+
+  # Builds a credit-note invoice for a refund.
+  # @param [Refund] refund
+  # @return [Invoice]
+  def self.build_from_refund(refund)
+    generation_json = generate_refund_hash(refund)
 
     new do |invoice|
       invoice.generation_json = generation_json
@@ -97,6 +110,42 @@ class Invoice < ApplicationRecord
           quantity: e.quantity
         }
       end
+    end
+
+    # @param [Refund] refund
+    def generate_refund_hash(refund)
+      {
+        version: 1,
+        type: 'credit_note',
+        original_invoice_number: refund.sale.invoice.number,
+        sale_date: Time.zone.today,
+        issue_date: Time.zone.today,
+        client_name: refund.sale.client.display_name,
+        client_address: refund.sale.client.display_address,
+        payment_amount: refund.credited_amount,
+        payment_method: refund.refund_method&.name,
+        payment_date: refund.cut_at,
+        items: refund_items_to_h(refund)
+      }.compact
+    end
+
+    # @param [Refund] refund
+    # @return [Array<Hash{Symbol=>String, Money, Integer}>]
+    def refund_items_to_h(refund)
+      items = refund.articles_refunds.map do |e|
+        {
+          item_name: e.article.name,
+          price: e.article.price,
+          quantity: e.quantity
+        }
+      end
+      return items unless refund.subscription_refunded?
+
+      items + [{
+        item_name: 'Remboursement abonnement',
+        price: refund.subscription_refund,
+        quantity: 1
+      }]
     end
   end
 end

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# It is recommended to instantiate a refund using {Refund.create_with_credit_note}
 class Refund < ApplicationRecord
   belongs_to :refunder, class_name: 'User', optional: true
   belongs_to :refund_method, class_name: 'PaymentMethod'
@@ -7,17 +8,86 @@ class Refund < ApplicationRecord
   belongs_to :invoice
   has_many :articles_refunds, dependent: :destroy
   has_many :articles, through: :articles_refunds
-  has_many :refunds_subscription_offers, dependent: :destroy
-  has_many :subscription_offers, through: :refunds_subscription_offers
 
-  def total_price
+  # Prorated credit for the cut subscription. NULL means no subscription was cut.
+  monetize :subscription_refund_cents, allow_nil: true
+
+  # Whether to cut the subscription, and the refund timestamp.
+  attr_accessor :refund_subscription, :cut_at
+
+  validate :not_empty_refund
+  validate :subscription_must_be_refundable
+
+  # @return [Boolean] whether this refund cut the sale's subscription
+  def subscription_refunded?
+    subscription_refund_cents.present?
+  end
+
+  # @return [Money]
+  def credited_amount
     total = Money.new(0)
-    articles_refunds.each do |rec|
-      total += rec.quantity * rec.article.price
-    end
-    refunds_subscription_offers.each do |rec|
-      total += rec.quantity * rec.subscription_offer.price
-    end
+    articles_refunds.each { |rec| total += rec.quantity * rec.article.price }
+    total += subscription_refund if subscription_refunded?
     total
+  end
+
+  # Builds (without saving) a refund and its credit-note invoice for the given sale.
+  # @return [Refund]
+  def self.build_with_credit_note(sale:, refund_method:, refunder:, refund_scope: {}, cut_at: Time.current)
+    new(sale: sale, refund_method: refund_method, refunder: refunder) do |refund|
+      refund.refund_subscription = refund_scope.fetch(:refund_subscription, false)
+      refund.cut_at = cut_at
+      refund.articles_refunds = build_articles_refunds(sale, refund_scope.fetch(:article_ids, []))
+      refund.subscription_refund_cents = subscription_credit_cents(sale, cut_at) if refund.refund_subscription
+      refund.invoice = Invoice.build_from_refund(refund)
+    end
+  end
+
+  # Atomically persists the refund and cuts the refunded subscription as of +cut_at+.
+  # The sale row is locked to serialize concurrent refunds, so an article can never be
+  # refunded twice and a subscription can never be cut twice.
+  # @return [Refund] persisted on success; otherwise carries validation errors (see #persisted?)
+  def self.create_with_credit_note(sale:, refund_method:, refunder:, refund_scope: {}, cut_at: Time.current)
+    refund = nil
+    transaction do
+      sale.lock!
+      refund = build_with_credit_note(sale: sale, refund_method: refund_method, refunder: refunder,
+                                      refund_scope: refund_scope, cut_at: cut_at)
+      raise ActiveRecord::Rollback unless refund.save
+
+      sale.subscription&.update!(cancelled_at: cut_at) if refund_scope.fetch(:refund_subscription, false)
+    end
+    refund
+  end
+
+  # Prorated subscription credit in cents, or nil when the sale has no subscription.
+  def self.subscription_credit_cents(sale, cut_at)
+    sale.subscription&.refund_amount(as_of: cut_at)&.cents
+  end
+  private_class_method :subscription_credit_cents
+
+  # Article lines selected for refund, filtered to those not already refunded.
+  def self.build_articles_refunds(sale, article_ids)
+    return [] if article_ids.blank?
+
+    sale.refundable_article_sales.where(article_id: article_ids).map do |article_sale|
+      ArticlesRefund.new(article: article_sale.article, quantity: article_sale.quantity)
+    end
+  end
+  private_class_method :build_articles_refunds
+
+  private
+
+  def not_empty_refund
+    return if articles_refunds.present? || subscription_refunded?
+
+    errors.add(:base, 'Cannot create an empty refund, select at least an article or the subscription')
+  end
+
+  def subscription_must_be_refundable
+    return unless refund_subscription
+    return if sale.subscription&.refundable?
+
+    errors.add(:base, 'The subscription cannot be refunded (already ended or cancelled)')
   end
 end

--- a/app/models/refunds_subscription_offer.rb
+++ b/app/models/refunds_subscription_offer.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class RefundsSubscriptionOffer < ApplicationRecord
-  belongs_to :refund
-  belongs_to :subscription_offer
-end

--- a/app/models/sale.rb
+++ b/app/models/sale.rb
@@ -46,11 +46,19 @@ class Sale < ApplicationRecord
     total
   end
 
+  # Article lines of this sale that have not yet been covered by a previous refund.
+  # An article can be refunded at most once (it appears at most once per sale).
+  # @return [ActiveRecord::Relation<ArticlesSale>]
+  def refundable_article_sales
+    already_refunded = ArticlesRefund.joins(:refund).where(refunds: { sale_id: id }).select(:article_id)
+    articles_sales.where.not(article_id: already_refunded)
+  end
+
   # @param [Hash] attributes
   # @param [User] seller
   def self.build_with_invoice(attributes = {}, seller:)
     new(attributes) do |sale|
-      sale.sales_subscription_offers = generate_sales_subscription_offers(sale.duration)
+      sale.sales_subscription_offers = SubscriptionPricing.basket_for(sale.duration)
       # Check if we have covered the entire subscription duration with subscription offers
       # (e.g., if we offer 12 months and 6 months but the user asks for 4 months, we cannot
       # cover the period and would have a non-zero remaining_duration, invalidated thanks
@@ -92,34 +100,5 @@ class Sale < ApplicationRecord
       .each { |article_sale| article_sale.errors.add(:article_id, :taken) }
 
     errors.add(:base, 'Please merge the quantities of the same articles')
-  end
-
-  class << self
-    private
-
-    # Find the best subscription offers for a given duration
-    # Example: if we ask for 14 months, with offers covering
-    # 12 months and 1 month, we return:
-    #   SalesSubscriptionOffer(12 months, quantity: 1)
-    #   SalesSubscriptionOffer(1 month, quantity: 2)
-    # @param [Integer] duration
-    # @return [Array<SalesSubscriptionOffer>]
-    def generate_sales_subscription_offers(duration)
-      return [] if duration <= 0
-
-      subscription_offers = SubscriptionOffer.sellable.order(duration: :desc)
-      sales_subscription_offers = []
-      subscription_offers.each do |offer|
-        break if duration == 0
-
-        quantity = duration / offer.duration
-        if quantity > 0
-          sales_subscription_offers << SalesSubscriptionOffer.new(subscription_offer_id: offer.id, quantity: quantity)
-          duration -= quantity * offer.duration
-        end
-      end
-
-      sales_subscription_offers
-    end
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -16,11 +16,13 @@ class Subscription < ApplicationRecord
     cancelled_at.nil? && end_at > Time.current
   end
 
-  # Number of months started since the purchase, as of as_of.
+  # Number of months started for more than 1 week since the purchase, as of as_of.
   # Months are measured as elapsed duration from start_at:
   # any partial month counts as a started month.
   # @return [Integer]
   def consumed_months(as_of: Time.current)
+    as_of -= 1.week # Grace period of 1 week to allow for full refunds within a week of a started month
+
     return 0 if as_of <= start_at
 
     # Find the smallest number of months needed to reach or exceed the target date

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,29 +5,26 @@ class Subscription < ApplicationRecord
 
   validates :start_at, presence: true
   validates :end_at, comparison: { greater_than: :start_at }
-  # validate :cannot_change_after_cancelled, on: :update
 
   def user
     sale.client
   end
 
-  # A subscription can be refunded (cut) only while it is still valid (not yet ended)
+  # A subscription can be refunded (cut) only while it is still valid
   # and has not already been cut by a previous refund.
   def refundable?
     cancelled_at.nil? && end_at > Time.current
   end
 
-  # Number of months *started* since the purchase, as of +as_of+.
-  # Months are measured as elapsed duration from start_at (not calendar months):
-  # any partial month counts as a started — and therefore non-refundable — month,
-  # while an exact month boundary counts as the lower value.
+  # Number of months started since the purchase, as of as_of.
+  # Months are measured as elapsed duration from start_at:
+  # any partial month counts as a started month.
   # @return [Integer]
   def consumed_months(as_of: Time.current)
     return 0 if as_of <= start_at
 
-    months = 1
-    months += 1 while start_at + months.months < as_of
-    months
+    # Find the smallest number of months needed to reach or exceed the target date
+    (1..).find { |months| start_at + months.months >= as_of } || 1
   end
 
   # Amount actually paid for this subscription's offers in its sale.
@@ -40,23 +37,10 @@ class Subscription < ApplicationRecord
     total
   end
 
-  # Credit-note amount when cutting this subscription as of +as_of+: what was paid,
+  # Credit-note amount when cutting this subscription as of as_of: what was paid,
   # minus what the consumed (started) months would cost at current rates, floored at zero.
   # @return [Money]
   def refund_amount(as_of: Time.current)
-    [paid - SubscriptionPricing.cost_for(consumed_months(as_of: as_of)), Money.new(0)].max
+    [paid - SubscriptionPricing.cost_for(consumed_months(as_of: as_of), at: created_at), Money.new(0)].max
   end
-
-  # def cancel!
-  #   self.cancelled_at = Time.current
-  #   save!
-  # end
-
-  # private
-
-  # def cannot_change_after_cancelled
-  #   return if cancelled_at_was.nil?
-  #
-  #   errors.add(:cancelled_at, 'Subscription has already been cancelled')
-  # end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -11,6 +11,42 @@ class Subscription < ApplicationRecord
     sale.client
   end
 
+  # A subscription can be refunded (cut) only while it is still valid (not yet ended)
+  # and has not already been cut by a previous refund.
+  def refundable?
+    cancelled_at.nil? && end_at > Time.current
+  end
+
+  # Number of months *started* since the purchase, as of +as_of+.
+  # Months are measured as elapsed duration from start_at (not calendar months):
+  # any partial month counts as a started — and therefore non-refundable — month,
+  # while an exact month boundary counts as the lower value.
+  # @return [Integer]
+  def consumed_months(as_of: Time.current)
+    return 0 if as_of <= start_at
+
+    months = 1
+    months += 1 while start_at + months.months < as_of
+    months
+  end
+
+  # Amount actually paid for this subscription's offers in its sale.
+  # @return [Money]
+  def paid
+    total = Money.new(0)
+    sale.sales_subscription_offers.each do |sso|
+      total += sso.quantity * sso.subscription_offer.price
+    end
+    total
+  end
+
+  # Credit-note amount when cutting this subscription as of +as_of+: what was paid,
+  # minus what the consumed (started) months would cost at current rates, floored at zero.
+  # @return [Money]
+  def refund_amount(as_of: Time.current)
+    [paid - SubscriptionPricing.cost_for(consumed_months(as_of: as_of)), Money.new(0)].max
+  end
+
   # def cancel!
   #   self.cancelled_at = Time.current
   #   save!

--- a/app/models/subscription_offer.rb
+++ b/app/models/subscription_offer.rb
@@ -3,8 +3,6 @@
 class SubscriptionOffer < ApplicationRecord
   has_many :sales_subscription_offers, dependent: :restrict_with_error
   has_many :sales, through: :sales_subscription_offers
-  has_many :refunds_subscription_offers, dependent: :restrict_with_error
-  has_many :refunds, through: :refunds_subscription_offers
 
   monetize :price_cents, numericality: { greater_than: 0 }
 

--- a/app/services/invoice_pdf_generator.rb
+++ b/app/services/invoice_pdf_generator.rb
@@ -26,10 +26,11 @@ class InvoiceLib
   class PDFMetadata
     attr_reader :title, :author, :subject, :creation_date
 
-    def initialize(number:)
-      @title = "Facture Rézoléo #{number}"
+    def initialize(number:, credit_note: false)
+      document_name = credit_note ? 'Avoir' : 'Facture'
+      @title = "#{document_name} Rézoléo #{number}"
       @author = 'Association Rézoléo'
-      @subject = "Facture #{number}"
+      @subject = "#{document_name} #{number}"
       @creation_date = Time.now.utc
     end
   end
@@ -53,9 +54,9 @@ class InvoicePdfGenerator
   # - :payment_method (String, optional) - Method of payment
   def initialize(input)
     @input = normalize_input(input)
-    @doc_metadata = InvoiceLib::PDFMetadata.new(number: @input[:number])
+    @doc_metadata = InvoiceLib::PDFMetadata.new(number: @input[:number], credit_note: credit_note?)
     @total_price = @input[:items].sum { |item| item[:price] * item[:quantity] }
-    @composer = InvoiceComposer.new
+    @composer = InvoiceComposer.new(document_title: credit_note? ? 'Avoir Rézoléo' : 'Facture Rézoléo')
     setup_document
   end
 
@@ -76,6 +77,10 @@ class InvoicePdfGenerator
 
   private
 
+  def credit_note?
+    @input[:type] == 'credit_note'
+  end
+
   def setup_document
     @composer.document.metadata.title(@doc_metadata.title)
     @composer.document.metadata.author(@doc_metadata.author)
@@ -84,15 +89,27 @@ class InvoicePdfGenerator
   end
 
   def add_invoice_header
-    invoice_header = <<~HEADER
+    @composer.text(invoice_header, style: :base, text_align: :center, margin: margin_bottom(2))
+    @composer.text('Association Rézoléo', style: :bold, margin: margin_bottom(1))
+    @composer.text(InvoiceLib::INFO_REZOLEO, margin: margin_bottom(2))
+  end
+
+  def invoice_header
+    return credit_note_header if credit_note?
+
+    <<~HEADER
       Facture n°#{@input[:number]}
       Date de vente : #{@input[:sale_date]}
       Date d'émission : #{@input[:issue_date]}
     HEADER
+  end
 
-    @composer.text(invoice_header, style: :base, text_align: :center, margin: margin_bottom(2))
-    @composer.text('Association Rézoléo (Trésorerie)', style: :bold, margin: margin_bottom(1))
-    @composer.text(InvoiceLib::INFO_REZOLEO, margin: margin_bottom(2))
+  def credit_note_header
+    <<~HEADER
+      Avoir n°#{@input[:number]}
+      Facture d'origine n°#{@input[:original_invoice_number]}
+      Date d'émission : #{@input[:issue_date]}
+    HEADER
   end
 
   def add_client_info
@@ -216,8 +233,9 @@ class InvoicePdfGenerator
   end
 
   class InvoiceComposer < HexaPDF::Composer
-    def initialize(page_size: :A4, page_orientation: :portrait, margin: 36)
-      super
+    def initialize(page_size: :A4, page_orientation: :portrait, margin: 36, document_title: 'Facture Rézoléo')
+      @document_title = document_title
+      super(page_size: page_size, page_orientation: page_orientation, margin: margin)
 
       document.task(:pdfa)
     end
@@ -232,7 +250,7 @@ class InvoicePdfGenerator
       config_font_style(font: 'DejaVu Sans')
 
       image(Rails.root.join('app/assets/images/rezoleo_logo.png').to_s, width: 75, position: :float, mask_mode: :none)
-      text('Facture Rézoléo', style: :header, margin: [0, 0, 2 * BASE_FONT_SIZE])
+      text(@document_title, style: :header, margin: [0, 0, 2 * BASE_FONT_SIZE])
       text(InvoiceLib::FOOTER, style: :footer, position: [0, 0])
     end
 

--- a/app/services/subscription_pricing.rb
+++ b/app/services/subscription_pricing.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Decomposes and prices subscription durations using a greedy, largest-offer-first
-# pass over the currently *sellable* offers.
+# pass over the sellable offers at a given time.
 #
 # - {.basket_for} mirrors sale creation: it greedily covers as much of the requested
 #   duration as possible and leaves any remainder uncovered (the caller validates
@@ -13,12 +13,13 @@ class SubscriptionPricing
   class NoSellableOfferError < StandardError; end
 
   # @param months [Integer]
-  # @return [Array<SalesSubscriptionOffer>] greedy decomposition; remainder left uncovered
-  def self.basket_for(months)
+  # @param at [TimeWithZone] the historical time to fetch the offers for
+  # @return [Array<SalesSubscriptionOffer>]
+  def self.basket_for(months, at: Time.current)
     return [] if months <= 0
 
     remaining = months
-    sellable_offers.each_with_object([]) do |offer, basket|
+    available_offers(at).each_with_object([]) do |offer, basket|
       quantity = remaining / offer.duration
       next unless quantity.positive?
 
@@ -28,11 +29,12 @@ class SubscriptionPricing
   end
 
   # @param months [Integer]
-  # @return [Money] price to cover at least +months+, rounding any remainder up
-  def self.cost_for(months)
+  # @param at [TimeWithZone] the historical time to fetch the offers for
+  # @return [Money] price to cover at least the number of months, rounding any remainder up
+  def self.cost_for(months, at: Time.current)
     return Money.new(0) if months <= 0
 
-    offers = sellable_offers
+    offers = available_offers(at)
     raise NoSellableOfferError, 'No sellable subscription offer to price a refund' if offers.empty?
 
     remaining = months
@@ -48,10 +50,15 @@ class SubscriptionPricing
     cost + rounded_up_remainder(offers, remaining)
   end
 
-  def self.sellable_offers
-    SubscriptionOffer.sellable.order(duration: :desc).to_a
+  # Fetches offers that were active at the given timestamp.
+  def self.available_offers(at)
+    SubscriptionOffer
+      .where(created_at: ..at)
+      .where('deleted_at IS NULL OR deleted_at > ?', at)
+      .order(duration: :desc)
+      .to_a
   end
-  private_class_method :sellable_offers
+  private_class_method :available_offers
 
   # Cover a leftover duration with the smallest-duration offer, rounding up.
   def self.rounded_up_remainder(offers, remaining)

--- a/app/services/subscription_pricing.rb
+++ b/app/services/subscription_pricing.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Decomposes and prices subscription durations using a greedy, largest-offer-first
+# pass over the currently *sellable* offers.
+#
+# - {.basket_for} mirrors sale creation: it greedily covers as much of the requested
+#   duration as possible and leaves any remainder uncovered (the caller validates
+#   exhaustiveness via Sale#exhaustive_subscription_offers).
+# - {.cost_for} prices a duration for refunds. Since you cannot buy a fraction of an
+#   offer, a remainder that the offers cannot tile exactly is rounded *up* to the next
+#   purchasable unit of the smallest offer.
+class SubscriptionPricing
+  class NoSellableOfferError < StandardError; end
+
+  # @param months [Integer]
+  # @return [Array<SalesSubscriptionOffer>] greedy decomposition; remainder left uncovered
+  def self.basket_for(months)
+    return [] if months <= 0
+
+    remaining = months
+    sellable_offers.each_with_object([]) do |offer, basket|
+      quantity = remaining / offer.duration
+      next unless quantity.positive?
+
+      basket << SalesSubscriptionOffer.new(subscription_offer_id: offer.id, quantity: quantity)
+      remaining -= quantity * offer.duration
+    end
+  end
+
+  # @param months [Integer]
+  # @return [Money] price to cover at least +months+, rounding any remainder up
+  def self.cost_for(months)
+    return Money.new(0) if months <= 0
+
+    offers = sellable_offers
+    raise NoSellableOfferError, 'No sellable subscription offer to price a refund' if offers.empty?
+
+    remaining = months
+    cost = Money.new(0)
+    offers.each do |offer|
+      quantity = remaining / offer.duration
+      next unless quantity.positive?
+
+      cost += quantity * offer.price
+      remaining -= quantity * offer.duration
+    end
+
+    cost + rounded_up_remainder(offers, remaining)
+  end
+
+  def self.sellable_offers
+    SubscriptionOffer.sellable.order(duration: :desc).to_a
+  end
+  private_class_method :sellable_offers
+
+  # Cover a leftover duration with the smallest-duration offer, rounding up.
+  def self.rounded_up_remainder(offers, remaining)
+    return Money.new(0) if remaining <= 0
+
+    smallest = offers.min_by(&:duration)
+    units = (remaining.to_f / smallest.duration).ceil
+    units * smallest.price
+  end
+  private_class_method :rounded_up_remainder
+end

--- a/app/views/refunds/_refund.html.erb
+++ b/app/views/refunds/_refund.html.erb
@@ -1,0 +1,24 @@
+<%# locals: (refund:) -%>
+
+<div class="refund">
+  <b>Refund</b>
+
+  <% refund.articles_refunds.each do |article_refund| %>
+    <p><%= article_refund.article.name %><% if article_refund.quantity > 1 %> (×<%= article_refund.quantity %>)<% end %></p>
+  <% end %>
+
+  <% if refund.subscription_refunded? %>
+    <p>Subscription cut</p>
+  <% end %>
+
+  <% if refund.reason.present? %>
+    <p>Reason: <%= refund.reason %></p>
+  <% end %>
+
+  <p>Credited: <%= refund.credited_amount.format %></p>
+
+  <%= link_to(download_invoice_path(refund.invoice), class: 'button-primary') do %>
+    Credit note
+    <%= svg_icon_tag 'icon_pdf' %>
+  <% end %>
+</div>

--- a/app/views/refunds/new.html.erb
+++ b/app/views/refunds/new.html.erb
@@ -1,0 +1,48 @@
+<%# locals: () -%>
+
+<main>
+  <h1 class="title">Refund sale for <%= @sale.client.display_name %></h1>
+
+  <%= form_with(url: sale_refunds_path(@sale), method: :post, class: 'form') do |f| %>
+    <%= render 'utils/error_messages', object: @refund %>
+
+    <fieldset>
+      <legend>Articles</legend>
+      <% if @refundable_article_sales.any? %>
+        <% @refundable_article_sales.each do |article_sale| %>
+          <div>
+            <%= check_box_tag 'refund[article_ids][]', article_sale.article_id, false,
+                              id: "refund_article_#{article_sale.article_id}" %>
+            <%= label_tag "refund_article_#{article_sale.article_id}",
+                          "#{article_sale.article.name} (×#{article_sale.quantity}) — " \
+                          "#{(article_sale.article.price * article_sale.quantity).format}" %>
+          </div>
+        <% end %>
+      <% else %>
+        <p>No refundable articles (already refunded or none on this sale).</p>
+      <% end %>
+    </fieldset>
+
+    <% if @subscription&.refundable? %>
+      <fieldset>
+        <legend>Subscription</legend>
+        <div>
+          <%= check_box_tag 'refund[refund_subscription]', '1', false, id: 'refund_refund_subscription' %>
+          <%= label_tag 'refund_refund_subscription',
+                        "Cut subscription now and credit #{@subscription.refund_amount.format}" %>
+        </div>
+      </fieldset>
+    <% end %>
+
+    <div>
+      <%= label_tag 'refund_refund_method_id', 'Refund method' %>
+      <%= select_tag 'refund[refund_method_id]',
+                     options_from_collection_for_select(@refund_methods, :id, :name),
+                     prompt: 'Select refund method' %>
+    </div>
+
+    <div>
+      <%= f.submit 'Create refund' %>
+    </div>
+  <% end %>
+</main>

--- a/app/views/sales/_sale.html.erb
+++ b/app/views/sales/_sale.html.erb
@@ -18,5 +18,10 @@
         <%= svg_icon_tag 'icon_pdf' %>
     <% end %>
 
+    <% if can?(:create, Refund) %>
+        <%= link_to 'Refund', new_sale_refund_path(sale), class: 'button-secondary' %>
+    <% end %>
+
+    <%= render sale.refunds %>
 
 </div>

--- a/db/migrate/20260624120000_rework_refund_schema.rb
+++ b/db/migrate/20260624120000_rework_refund_schema.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ReworkRefundSchema < ActiveRecord::Migration[7.2]
+  def change
+    # Store the prorated subscription credit. NULL means the refund did not cut a
+    # subscription; a value (including 0) means it did. This is the one non-derivable
+    # amount of a refund (article credits stay derivable from articles_refunds).
+    add_column :refunds, :subscription_refund_cents, :integer
+
+    # A refund cuts the sale's single subscription as a unit and credits a prorated
+    # amount, so the per-offer breakdown is redundant (reachable via refund -> sale)
+    # and its quantity no longer drives the credit. subscription_refund_cents replaces
+    # it as both the amount and the "subscription was cut" marker.
+    drop_table :refunds_subscription_offers, primary_key: [:refund_id, :subscription_offer_id] do |t|
+      t.references :refund, null: false, foreign_key: true
+      t.references :subscription_offer, null: false, foreign_key: true
+      t.integer :quantity, null: false
+    end
+
+    remove_foreign_key :refunds, :users, column: :refunder_id
+    add_foreign_key :refunds, :users, column: :refunder_id, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_07_123053) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_24_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -128,18 +128,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_07_123053) do
     t.datetime "verified_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "subscription_refund_cents"
     t.index ["invoice_id"], name: "index_refunds_on_invoice_id"
     t.index ["refund_method_id"], name: "index_refunds_on_refund_method_id"
     t.index ["refunder_id"], name: "index_refunds_on_refunder_id"
     t.index ["sale_id"], name: "index_refunds_on_sale_id"
-  end
-
-  create_table "refunds_subscription_offers", primary_key: ["refund_id", "subscription_offer_id"], force: :cascade do |t|
-    t.bigint "refund_id", null: false
-    t.bigint "subscription_offer_id", null: false
-    t.integer "quantity", null: false
-    t.index ["refund_id"], name: "index_refunds_subscription_offers_on_refund_id"
-    t.index ["subscription_offer_id"], name: "index_refunds_subscription_offers_on_subscription_offer_id"
   end
 
   create_table "rooms", force: :cascade do |t|
@@ -232,9 +225,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_07_123053) do
   add_foreign_key "refunds", "invoices"
   add_foreign_key "refunds", "payment_methods", column: "refund_method_id"
   add_foreign_key "refunds", "sales"
-  add_foreign_key "refunds", "users", column: "refunder_id"
-  add_foreign_key "refunds_subscription_offers", "refunds"
-  add_foreign_key "refunds_subscription_offers", "subscription_offers"
+  add_foreign_key "refunds", "users", column: "refunder_id", on_delete: :nullify
   add_foreign_key "rooms", "users"
   add_foreign_key "sales", "invoices"
   add_foreign_key "sales", "payment_methods"

--- a/docs/features/subscription.md
+++ b/docs/features/subscription.md
@@ -13,3 +13,21 @@ graph TD
 If a user has a free access when a subscription is added, the starting date
 of the subscription is based on the subscription expiration status, *not* the internet
 expiration status.
+
+## Refunding subscriptions
+
+When a subscription is refunded, the system calculates a credit-note amount
+based on what was paid minus the cost of consumed months.
+
+There is a 1-week grace period from the start date of each month. Within this
+grace period, the month is not considered as consumed, allowing users to
+get a full refund within one week of a started month.
+
+The refund amount is calculated as follows:
+
+```
+Refund = Amount paid - Cost of consumed months (floored at zero)
+```
+
+where the cost of consumed months is determined using `SubscriptionPricing.cost_for()`,
+which uses a greedy algorithm based on available offers at the time of subscription purchase.

--- a/test/controllers/refunds_controller_test.rb
+++ b/test/controllers/refunds_controller_test.rb
@@ -3,7 +3,38 @@
 require 'test_helper'
 
 class RefundsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    super
+    @admin = users(:ironman)
+    @sale = sales(:ironman_deleted_article)
+    @article = articles(:deleted_article)
+    @refund_method = payment_methods(:cash)
+    sign_in_as @admin, ['rezoleo']
+  end
+
+  test 'should get new refund form' do
+    get new_sale_refund_path(@sale)
+    assert_response :success
+    assert_template 'refunds/new'
+    assert_select 'form'
+  end
+
+  test 'should create a refund and redirect to the client' do
+    assert_difference 'Refund.count', 1 do
+      post sale_refunds_path(@sale), params: { refund: {
+        refund_method_id: @refund_method.id,
+        article_ids: [@article.id]
+      } }
+    end
+    assert_redirected_to @sale.client
+    assert_equal 'Refund created!', flash[:success]
+  end
+
+  test 'should not create an empty refund' do
+    assert_no_difference 'Refund.count' do
+      post sale_refunds_path(@sale), params: { refund: { refund_method_id: @refund_method.id } }
+    end
+    assert_response :unprocessable_entity
+    assert_template 'refunds/new'
+  end
 end

--- a/test/controllers/refunds_controller_user_right_test.rb
+++ b/test/controllers/refunds_controller_user_right_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RefundsControllerUserRightTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+    @user = users(:pepper)
+    @sale = sales(:ironman_deleted_article)
+    sign_in_as @user
+  end
+
+  test 'non-admin user should not see refund creation page' do
+    assert_raises CanCan::AccessDenied do
+      get new_sale_refund_path(@sale)
+    end
+  end
+
+  test 'non-admin user should not create a refund' do
+    assert_raises CanCan::AccessDenied do
+      post sale_refunds_path(@sale), params: { refund: {
+        refund_method_id: payment_methods(:cash).id,
+        article_ids: [articles(:deleted_article).id]
+      } }
+    end
+  end
+end

--- a/test/fixtures/invoices.yml
+++ b/test/fixtures/invoices.yml
@@ -81,3 +81,20 @@ sale_ironman_deleted_article:
     client_address: "Appartement A200\nRésidence Léonard de Vinci\nAvenue Paul Langevin\n59650 Villeneuve-d'Ascq"
     payment_method: "Credit card"
     payment_amount_cent: 2000
+
+refund_pepper_1_year:
+  number: 6
+  generation_json:
+    type: "credit_note"
+    original_invoice_number: 2
+    items:
+      - quantity: 1
+        item_name: "Remboursement abonnement"
+        price_cents: 1000
+    sale_date: "2025-02-01"
+    issue_date: "2025-02-01"
+    client_name: "Pepper POTTS"
+    payment_date: "2025-02-01T10:00:00.000Z"
+    client_address: "Appartement A201\nRésidence Léonard de Vinci\nAvenue Paul Langevin\n59650 Villeneuve-d'Ascq"
+    payment_method: "Cash"
+    payment_amount_cent: 1000

--- a/test/fixtures/refunds.yml
+++ b/test/fixtures/refunds.yml
@@ -7,3 +7,4 @@ ironman_cable_adapter_4_months:
   invoice: refund_ironman_cable_4_months
   reason: Leaving the residence
   verified_at: 2025-01-30 14:37:19
+  subscription_refund_cents: 2000

--- a/test/fixtures/refunds.yml
+++ b/test/fixtures/refunds.yml
@@ -8,3 +8,12 @@ ironman_cable_adapter_4_months:
   reason: Leaving the residence
   verified_at: 2025-01-30 14:37:19
   subscription_refund_cents: 2000
+
+pepper_1_year_refund:
+  refunder: ironman
+  refund_method: cash
+  sale: pepper_1_year
+  invoice: refund_pepper_1_year
+  reason: Test refund
+  verified_at: 2025-02-01 10:00:00
+  subscription_refund_cents: 1000

--- a/test/fixtures/refunds_subscription_offers.yml
+++ b/test/fixtures/refunds_subscription_offers.yml
@@ -1,6 +1,0 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-ironman_4_months:
-  refund: ironman_cable_adapter_4_months
-  subscription_offer: month
-  quantity: 4

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -2,4 +2,4 @@
 
 next_invoice_number:
   key: "next_invoice_number"
-  value: "6"
+  value: "7"

--- a/test/fixtures/subscription_offers.yml
+++ b/test/fixtures/subscription_offers.yml
@@ -3,22 +3,27 @@
 month:
   duration: 1
   price_cents: 500
+  created_at: 2025-01-01 00:00:00
 
 year:
   duration: 12
   price_cents: 5000
+  created_at: 2025-01-01 00:00:00
 
 2_months:
   duration: 2
   price_cents: 1600
+  created_at: 2023-01-01 00:00:00
   deleted_at: 2025-01-01 00:00:00
 
 month_old:
   duration: 1
   price_cents: 800
+  created_at: 2023-01-01 00:00:00
   deleted_at: 2025-01-01 00:00:00
 
 year_old:
   duration: 12
   price_cents: 8000
+  created_at: 2023-01-01 00:00:00
   deleted_at: 2025-01-01 00:00:00

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -5,6 +5,14 @@ require 'test_helper'
 class AbilityTest < ActiveSupport::TestCase
   def setup
     super
+    setup_user_fixtures
+    setup_admin_fixtures
+
+    @api_key = api_keys(:FakeRadius)
+    @api_key_ability = ApiKeyAbility.new(@api_key)
+  end
+
+  def setup_user_fixtures
     @user = users(:pepper)
     @user_ability = UserAbility.new(@user)
     @user_machine = @user.machines.first
@@ -14,16 +22,19 @@ class AbilityTest < ActiveSupport::TestCase
     @other_user_sale = sales(:ironman_cable_6_months)
     @user_invoice = invoices(:sale_pepper_1_year)
     @other_user_invoice = invoices(:sale_ironman_cable_6_months)
+    @user_refund = refunds(:pepper_1_year_refund)
+    @other_user_refund = refunds(:ironman_cable_adapter_4_months)
+    @user_refund_invoice = invoices(:refund_pepper_1_year)
+    @other_user_refund_invoice = invoices(:refund_ironman_cable_4_months)
+  end
 
+  def setup_admin_fixtures
     @admin = users(:ironman)
     @admin.groups = ['rezoleo'] # runtime value, cannot be set in fixture
     @admin_ability = UserAbility.new(@admin)
     @admin_machine = @admin.machines.first
     @admin_subscription = @admin.subscriptions.first
     @admin_free_access = @admin.free_accesses.first
-
-    @api_key = api_keys(:FakeRadius)
-    @api_key_ability = ApiKeyAbility.new(@api_key)
   end
 
   test 'user can read themselves' do
@@ -90,6 +101,16 @@ class AbilityTest < ActiveSupport::TestCase
   test 'user can read their invoice but not others' do
     assert @user_ability.can?(:read, @user_invoice)
     assert @user_ability.cannot?(:read, @other_user_invoice)
+  end
+
+  test 'user can read their refund but not others' do
+    assert @user_ability.can?(:read, @user_refund)
+    assert @user_ability.cannot?(:read, @other_user_refund)
+  end
+
+  test 'user can read their refund credit-note invoice but not others' do
+    assert @user_ability.can?(:read, @user_refund_invoice)
+    assert @user_ability.cannot?(:read, @other_user_refund_invoice)
   end
 
   test 'user cannot create a new subscription to themselves' do

--- a/test/models/refund_test.rb
+++ b/test/models/refund_test.rb
@@ -14,14 +14,81 @@ class RefundTest < ActiveSupport::TestCase
     end
   end
 
-  test 'destroy refund should destroy refunds_subscription_offers' do
-    assert_difference 'RefundsSubscriptionOffer.count', -1 do
-      @refund.destroy
-    end
+  test 'credited_amount sums refunded articles and the stored subscription credit' do
+    # cable (2 €) + stored subscription credit (20 €)
+    assert_equal Money.new(2200, :eur), @refund.credited_amount
   end
 
-  test 'total_price should calculate refund total from articles and subscription offers' do
-    expected_total = Money.new(2200, :eur)
-    assert_equal expected_total, @refund.total_price
+  test 'create_with_credit_note refunds an article and generates a credit note' do
+    sale = sales(:ironman_deleted_article)
+    article = articles(:deleted_article)
+
+    refund = nil
+    assert_difference ['Refund.count', 'ArticlesRefund.count', 'Invoice.count'], 1 do
+      refund = Refund.create_with_credit_note(
+        sale: sale, refund_method: payment_methods(:cash), refunder: users(:ironman),
+        refund_scope: { article_ids: [article.id] }
+      )
+    end
+
+    assert_predicate refund, :persisted?
+    assert_equal [article.id], refund.articles_refunds.map(&:article_id)
+    assert_equal Money.new(2000, :eur), refund.credited_amount
+    assert_equal 6, refund.invoice.number # next_invoice_number fixture
+    assert_equal users(:ironman), refund.invoice.user
+  end
+
+  test 'create_with_credit_note cuts the subscription and prorates the credit' do
+    sale = sales(:spiderman_1_year) # 1 year (50 €), starts in 2099 => not yet consumed
+    subscription = subscriptions(:subscription3)
+
+    refund = nil
+    assert_difference 'Refund.count', 1 do
+      refund = Refund.create_with_credit_note(
+        sale: sale, refund_method: payment_methods(:cash), refunder: users(:ironman),
+        refund_scope: { refund_subscription: true }
+      )
+    end
+
+    assert_predicate refund, :persisted?
+    assert_predicate refund, :subscription_refunded?
+    assert_equal Money.new(5000, :eur), refund.credited_amount # nothing consumed yet => full refund
+    assert_equal 5000, refund.subscription_refund_cents
+    assert_not_nil subscription.reload.cancelled_at
+    assert_not_predicate subscription, :refundable?
+  end
+
+  test 'create_with_credit_note rejects an empty refund' do
+    refund = Refund.create_with_credit_note(
+      sale: sales(:ironman_deleted_article), refund_method: payment_methods(:cash), refunder: users(:ironman)
+    )
+
+    assert_not_predicate refund, :persisted?
+    assert refund.errors.added?(:base, 'Cannot create an empty refund, select at least an article or the subscription')
+  end
+
+  test 'create_with_credit_note rejects refunding an ended subscription' do
+    sale = sales(:pepper_1_year) # subscription2 ended in 2023
+
+    refund = Refund.create_with_credit_note(
+      sale: sale, refund_method: payment_methods(:cash), refunder: users(:ironman),
+      refund_scope: { refund_subscription: true }
+    )
+
+    assert_not_predicate refund, :persisted?
+    assert refund.errors.added?(:base, 'The subscription cannot be refunded (already ended or cancelled)')
+  end
+
+  test 'create_with_credit_note prevents refunding the same article twice' do
+    sale = sales(:ironman_deleted_article)
+    article = articles(:deleted_article)
+    args = { sale: sale, refund_method: payment_methods(:cash), refunder: users(:ironman),
+             refund_scope: { article_ids: [article.id] } }
+
+    assert_predicate Refund.create_with_credit_note(**args), :persisted?
+
+    second = Refund.create_with_credit_note(**args)
+    assert_not_predicate second, :persisted?
+    assert_empty sale.refundable_article_sales
   end
 end

--- a/test/models/refund_test.rb
+++ b/test/models/refund_test.rb
@@ -34,7 +34,7 @@ class RefundTest < ActiveSupport::TestCase
     assert_predicate refund, :persisted?
     assert_equal [article.id], refund.articles_refunds.map(&:article_id)
     assert_equal Money.new(2000, :eur), refund.credited_amount
-    assert_equal 6, refund.invoice.number # next_invoice_number fixture
+    assert_equal 7, refund.invoice.number # next_invoice_number fixture
     assert_equal users(:ironman), refund.invoice.user
   end
 

--- a/test/models/sale_test.rb
+++ b/test/models/sale_test.rb
@@ -137,6 +137,16 @@ class SaleTest < ActiveSupport::TestCase
     assert_equal expected_total, @sale.total_price
   end
 
+  test 'refundable_article_sales excludes articles already refunded' do
+    # The cable line of this sale is already covered by the refund fixture.
+    assert_empty @sale.refundable_article_sales
+  end
+
+  test 'refundable_article_sales returns lines not yet refunded' do
+    sale = sales(:ironman_deleted_article)
+    assert_equal [articles(:deleted_article).id], sale.refundable_article_sales.map(&:article_id)
+  end
+
   test 'save should return false when invoice is nil' do
     sale = Sale.new(
       client: @user,

--- a/test/models/subscription_offer_test.rb
+++ b/test/models/subscription_offer_test.rb
@@ -64,7 +64,6 @@ class SubscriptionOfferTest < ActiveSupport::TestCase
 
   test 'offer should be destroyed if no sales' do
     @subscription_offer.sales.destroy_all
-    @subscription_offer.refunds.destroy_all
     assert_difference 'SubscriptionOffer.count', -1 do
       assert_predicate @subscription_offer, :destroy
     end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -31,6 +31,71 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_not_predicate @subscription, :valid?
   end
 
+  test 'refundable? only when still running and not cancelled' do
+    travel_to Time.zone.local(2023, 3, 1, 12) do
+      running = Subscription.new(start_at: Time.zone.local(2023, 1, 1), end_at: Time.zone.local(2023, 6, 1))
+      assert_predicate running, :refundable?
+
+      # Not yet started but still valid in the future
+      future = Subscription.new(start_at: Time.zone.local(2099, 1, 1), end_at: Time.zone.local(2099, 6, 1))
+      assert_predicate future, :refundable?
+
+      over = Subscription.new(start_at: Time.zone.local(2022, 1, 1), end_at: Time.zone.local(2022, 6, 1))
+      assert_not_predicate over, :refundable?
+
+      cancelled = Subscription.new(start_at: Time.zone.local(2023, 1, 1), end_at: Time.zone.local(2023, 6, 1),
+                                   cancelled_at: Time.zone.local(2023, 2, 1))
+      assert_not_predicate cancelled, :refundable?
+    end
+  end
+
+  test 'consumed_months is zero before the subscription starts' do
+    subscription = Subscription.new(start_at: Time.zone.local(2023, 1, 1, 12))
+
+    assert_equal 0, subscription.consumed_months(as_of: Time.zone.local(2022, 12, 31, 12))
+    assert_equal 0, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 1, 12))
+  end
+
+  test 'consumed_months rounds a started month up' do
+    subscription = Subscription.new(start_at: Time.zone.local(2023, 1, 1, 12))
+
+    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 1, 12, 0, 1))
+    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 15, 12))
+  end
+
+  test 'consumed_months counts an exact month boundary as the lower value' do
+    subscription = Subscription.new(start_at: Time.zone.local(2023, 1, 1, 12))
+
+    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 2, 1, 12))
+    assert_equal 2, subscription.consumed_months(as_of: Time.zone.local(2023, 3, 1, 12))
+    assert_equal 2, subscription.consumed_months(as_of: Time.zone.local(2023, 2, 1, 12, 0, 1))
+  end
+
+  test 'paid sums the price of the subscription offers in the sale' do
+    # subscription2 -> pepper_1_year -> 1 year offer (50 €)
+    assert_equal Money.new(5000, :eur), subscriptions(:subscription2).paid
+  end
+
+  test 'refund_amount gives a full refund before the subscription starts' do
+    subscription = subscriptions(:subscription2) # paid 50 €, starts 2023-01-07
+
+    assert_equal Money.new(5000, :eur), subscription.refund_amount(as_of: Time.zone.local(2023, 1, 1, 12))
+  end
+
+  test 'refund_amount is paid minus the cost of consumed months' do
+    subscription = subscriptions(:subscription2) # paid 50 €, starts 2023-01-07
+
+    # 3 months + 1 day -> 4 consumed months -> 4 × 5 € = 20 € consumed -> 30 € refunded
+    assert_equal Money.new(3000, :eur), subscription.refund_amount(as_of: Time.zone.local(2023, 4, 8, 12))
+  end
+
+  test 'refund_amount is floored at zero when consumed cost exceeds what was paid' do
+    subscription = subscriptions(:subscription2) # paid 50 €, starts 2023-01-07
+
+    # 14 consumed months -> 1 year + 2 months = 60 € > 50 € paid -> floored at 0
+    assert_equal Money.new(0, :eur), subscription.refund_amount(as_of: Time.zone.local(2024, 2, 8, 12))
+  end
+
   # test "cancelled_at can't be changed when not nil" do
   #   subscription = @user.subscriptions.new(start_at: Time.current,
   # end_at: 1.month.from_now, cancelled_at: Time.current)

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -56,19 +56,16 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_equal 0, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 1, 12))
   end
 
-  test 'consumed_months rounds a started month up' do
+  test 'consumed_months respects the 7-day grace period' do
     subscription = Subscription.new(start_at: Time.zone.local(2023, 1, 1, 12))
 
-    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 1, 12, 0, 1))
-    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 15, 12))
-  end
+    # First month: fully refundable during the first week
+    assert_equal 0, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 8, 11, 59, 59))
+    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 1, 8, 12, 0, 1))
 
-  test 'consumed_months counts an exact month boundary as the lower value' do
-    subscription = Subscription.new(start_at: Time.zone.local(2023, 1, 1, 12))
-
-    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 2, 1, 12))
-    assert_equal 2, subscription.consumed_months(as_of: Time.zone.local(2023, 3, 1, 12))
-    assert_equal 2, subscription.consumed_months(as_of: Time.zone.local(2023, 2, 1, 12, 0, 1))
+    # Second month: another one-week grace period
+    assert_equal 1, subscription.consumed_months(as_of: Time.zone.local(2023, 2, 8, 11, 59, 59))
+    assert_equal 2, subscription.consumed_months(as_of: Time.zone.local(2023, 2, 8, 12, 0, 1))
   end
 
   test 'paid sums the price of the subscription offers in the sale' do
@@ -85,8 +82,8 @@ class SubscriptionTest < ActiveSupport::TestCase
   test 'refund_amount is paid minus the cost of consumed months' do
     subscription = subscriptions(:subscription2) # paid 50 €, starts 2023-01-07
 
-    # 3 months + 1 day -> 4 consumed months -> 4 × 5 € = 20 € consumed -> 30 € refunded
-    assert_equal Money.new(3000, :eur), subscription.refund_amount(as_of: Time.zone.local(2023, 4, 8, 12))
+    # 3 months + 8 days -> 4 consumed months -> 4 × 5 € = 20 € consumed -> 30 € refunded
+    assert_equal Money.new(3000, :eur), subscription.refund_amount(as_of: Time.zone.local(2023, 4, 15, 12))
   end
 
   test 'refund_amount is floored at zero when consumed cost exceeds what was paid' do

--- a/test/services/invoice_pdf_generator_test.rb
+++ b/test/services/invoice_pdf_generator_test.rb
@@ -96,6 +96,32 @@ class InvoicePdfGeneratorTest < ActiveSupport::TestCase
     assert_equal Time.current.utc, metadata[:CreationDate]
   end
 
+  test 'generate_pdf renders a credit note for refunds' do
+    generator = InvoicePdfGenerator.new(
+      number: '4270',
+      type: 'credit_note',
+      original_invoice_number: 1234,
+      sale_date: '2024-07-22',
+      issue_date: '2024-07-22',
+      client_name: users(:ironman).display_name,
+      client_address: users(:ironman).display_address,
+      items: [{ item_name: 'Remboursement abonnement', price: Money.new(3000, 'EUR'), quantity: 1 }],
+      payment_amount: Money.new(3000, 'EUR'),
+      payment_date: '2024-07-22',
+      payment_method: 'Cash'
+    )
+    pdf = generator.generate_pdf
+
+    pdf_text = extract_text_from_pdf(pdf)
+    assert_includes pdf_text, 'Avoir Rézoléo'
+    assert_includes pdf_text, 'Avoir n°4270'
+    assert_includes pdf_text, "Facture d'origine n°1234"
+
+    metadata = extract_metadata_from_pdf(pdf)
+    assert_equal 'Avoir Rézoléo 4270', metadata[:Title]
+    assert_equal 'Avoir 4270', metadata[:Subject]
+  end
+
   class CollectTextProcessor < HexaPDF::Content::Processor
     def initialize(page, content)
       super()

--- a/test/services/subscription_pricing_test.rb
+++ b/test/services/subscription_pricing_test.rb
@@ -51,4 +51,14 @@ class SubscriptionPricingTest < ActiveSupport::TestCase
       SubscriptionPricing.cost_for(1)
     end
   end
+
+  test 'cost_for uses historical prices based on at parameter' do
+    historical_time = Time.utc(2024, 6, 1)
+
+    assert_equal Money.new(800, :eur), SubscriptionPricing.cost_for(1, at: historical_time)
+    assert_equal Money.new(500, :eur), SubscriptionPricing.cost_for(1)
+
+    assert_equal Money.new(9600, :eur), SubscriptionPricing.cost_for(14, at: historical_time)
+    assert_equal Money.new(6000, :eur), SubscriptionPricing.cost_for(14)
+  end
 end

--- a/test/services/subscription_pricing_test.rb
+++ b/test/services/subscription_pricing_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SubscriptionPricingTest < ActiveSupport::TestCase
+  # Sellable fixtures: month (1 month / 5 €), year (12 months / 50 €).
+
+  test 'basket_for returns nothing for a non-positive duration' do
+    assert_empty SubscriptionPricing.basket_for(0)
+    assert_empty SubscriptionPricing.basket_for(-3)
+  end
+
+  test 'basket_for decomposes greedily, largest offer first' do
+    basket = SubscriptionPricing.basket_for(14)
+
+    by_offer = basket.to_h { |sso| [sso.subscription_offer_id, sso.quantity] }
+    assert_equal 1, by_offer[subscription_offers(:year).id]
+    assert_equal 2, by_offer[subscription_offers(:month).id]
+  end
+
+  test 'basket_for leaves no remainder uncovered when an offer cannot fit' do
+    basket = SubscriptionPricing.basket_for(11)
+
+    assert_equal 1, basket.length
+    assert_equal subscription_offers(:month).id, basket.first.subscription_offer_id
+    assert_equal 11, basket.first.quantity
+  end
+
+  test 'cost_for is zero for a non-positive duration' do
+    assert_equal Money.new(0, :eur), SubscriptionPricing.cost_for(0)
+    assert_equal Money.new(0, :eur), SubscriptionPricing.cost_for(-1)
+  end
+
+  test 'cost_for prices the greedy decomposition' do
+    assert_equal Money.new(5000, :eur), SubscriptionPricing.cost_for(12)
+    assert_equal Money.new(6000, :eur), SubscriptionPricing.cost_for(14) # 1 year + 2 months
+    assert_equal Money.new(500, :eur), SubscriptionPricing.cost_for(1)
+  end
+
+  test 'cost_for rounds the remainder up to the smallest sellable offer' do
+    subscription_offers(:month).soft_delete # only the 12-month offer remains sellable
+
+    # 5 months cannot be tiled by a 12-month offer, so round up to one full year.
+    assert_equal Money.new(5000, :eur), SubscriptionPricing.cost_for(5)
+  end
+
+  test 'cost_for raises when no offer is sellable' do
+    SubscriptionOffer.find_each(&:soft_delete)
+
+    assert_raises(SubscriptionPricing::NoSellableOfferError) do
+      SubscriptionPricing.cost_for(1)
+    end
+  end
+end


### PR DESCRIPTION
Implement the full Refund workflow
- Compute subscription refund amount
- Generate Credit note ("Avoir")
- Remove unused `RefundsSubscriptionOffer` : a subscription offer is not "refunded" like an article, it is the subscription itself that can be cut at an earlier date, resulting or not in some money refund.
- Add refunds to the user page

links to #455 