### PR TITLE
fix(api): enhance error handling and improve robustness

### DIFF
--- a/app/abilities/api_key_ability.rb
+++ b/app/abilities/api_key_ability.rb
@@ -8,7 +8,7 @@ class ApiKeyAbility
 
     can :read, :all
     can [:create], Machine do |machine|
-      machine.user.machines.size <= USER_MACHINES_LIMIT
+      machine.user.machines.count < USER_MACHINES_LIMIT
     end
   end
 end

--- a/app/abilities/user_ability.rb
+++ b/app/abilities/user_ability.rb
@@ -10,7 +10,7 @@ class UserAbility
     can [:read, :update, :destroy], Machine, user: user
     # User can create a new machine to themselves if they don't have too many machines
     can [:create], Machine do |machine|
-      machine.user == user && user.machines.size < USER_MACHINES_LIMIT
+      machine.user == user && user.machines.count < USER_MACHINES_LIMIT
     end
 
     can [:read], Subscription, user: user

--- a/app/controllers/api/api_application_controller.rb
+++ b/app/controllers/api/api_application_controller.rb
@@ -4,6 +4,10 @@ module Api
   class ApiApplicationController < ActionController::API
     include ActionController::HttpAuthentication::Token::ControllerMethods
 
+    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+    rescue_from ActiveRecord::StatementInvalid, with: :render_bad_request
+    rescue_from CanCan::AccessDenied, with: :render_forbidden
+
     before_action :api_auth
 
     def current_ability
@@ -13,9 +17,41 @@ module Api
     private
 
     def api_auth
-      @current_api_key = authenticate_or_request_with_http_token do |token, _options|
+      @current_api_key = authenticate_with_http_token do |token, _options|
         ApiKey.authenticate_by_token token
       end
+
+      render_unauthorized if @current_api_key.nil?
+    end
+
+    def render_unauthorized
+      headers['WWW-Authenticate'] = 'Bearer realm="Application"'
+
+      render json: {
+        code: 'unauthorized',
+        message: 'You need to provide a valid API key to access this resource.'
+      }, status: :unauthorized
+    end
+
+    def render_not_found(_exception)
+      render json: {
+        code: 'not_found',
+        message: 'The requested resource was not found.'
+      }, status: :not_found
+    end
+
+    def render_bad_request(_exception)
+      render json: {
+        code: 'bad_request',
+        message: 'The requested resource was invalid.'
+      }, status: :bad_request
+    end
+
+    def render_forbidden(_exception)
+      render json: {
+        code: 'forbidden',
+        message: 'You are not authorized to perform this action.'
+      }, status: :forbidden
     end
   end
 end

--- a/app/controllers/api/machines_controller.rb
+++ b/app/controllers/api/machines_controller.rb
@@ -9,9 +9,9 @@ module Api
       @machines = Machine.accessible_by(current_ability)
       return if params[:has_connection].blank?
 
-      @machines = @machines.includes(user: [:valid_subscriptions_by_date, :free_accesses_by_date]).select do |machine|
-        machine if machine.user.internet_access?
-      end
+      @machines = @machines
+                  .includes(user: [:valid_subscriptions_by_date, :free_accesses_by_date])
+                  .select { |machine| machine.user.internet_access? }
     end
 
     def show

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -10,9 +10,7 @@ module Api
       @user = User.find_by!(username: params[:username])
       authorize! :show, @user
       @machines = @user.machines.includes(:ip).order(created_at: :asc)
-      openssl_legacy_provider = OpenSSL::Provider.load('legacy')
-      @ntlm_password = OpenSSL::Digest::MD4.hexdigest(@user.wifi_password.encode('utf-16le'))
-      openssl_legacy_provider.unload
+      @ntlm_password = @user.ntlm_password
     end
   end
 end

--- a/app/controllers/machines_controller.rb
+++ b/app/controllers/machines_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class MachinesController < ApplicationController
-  protect_from_forgery unless: -> { request.format.json? }
-
   before_action :owner, only: [:create, :new]
   before_action :current_machine, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  protect_from_forgery unless: -> { request.format.json? }
-
   def index
     @users = User.accessible_by(current_ability)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,8 +25,7 @@ class User < ApplicationRecord
 
   validates :firstname, presence: true, allow_blank: false
   validates :lastname, presence: true, allow_blank: false
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :wifi_password, presence: true, allow_blank: false
   validates :username, presence: true, uniqueness: true, allow_blank: false
   validate :room_number_must_exist
@@ -74,12 +73,19 @@ class User < ApplicationRecord
   end
 
   # @param [Integer] duration subscription duration in months
-  # @return [Subscription] the newly created subscription
+  # @return [Subscription, nil] an unsaved subscription record or nil when duration <= 0
   def extend_subscription(duration:)
     return if duration <= 0
 
     start_at = subscription_expired? ? Time.current : subscription_expiration
     subscriptions.new(start_at: start_at, end_at: start_at + duration.months)
+  end
+
+  # NTLM (MD4) hash of the Wi-Fi password used by FreeRADIUS. Requires the legacy
+  # provider loaded in config/initializers/openssl_legacy.rb.
+  # @return [String]
+  def ntlm_password
+    OpenSSL::Digest::MD4.hexdigest(wifi_password.encode('utf-16le'))
   end
 
   def self.upsert_from_auth_hash(auth_hash)

--- a/config/initializers/openssl_legacy.rb
+++ b/config/initializers/openssl_legacy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'openssl'
+
+# FreeRADIUS integration needs the NTLM (MD4) hash of the stored Wi-Fi password.
+# MD4 lives in OpenSSL 3's "legacy" provider. Loading it once at boot instead of
+# per-request: OpenSSL::Provider.load/unload mutate process-global state and are
+# not safe to toggle from multiple Puma threads concurrently.
+
+# NOTE: explicitly loading a provider can stop OpenSSL from auto-activating the
+# "default" provider, so load it as well to be safe.
+OpenSSL::Provider.load('default')
+OpenSSL::Provider.load('legacy')

--- a/test/controllers/api/machines_controller_test.rb
+++ b/test/controllers/api/machines_controller_test.rb
@@ -72,10 +72,9 @@ module Api
       assert_response :not_found
     end
 
-    test 'should raise an error when querying machines by invalid mac address with api key' do
-      assert_raises ActiveRecord::StatementInvalid do
-        get api_machine_url('invalid_mac'), headers: { 'Authorization' => "Bearer #{@original_key}" }
-      end
+    test 'should return bad request when querying machines by invalid mac address with api key' do
+      get api_machine_url('invalid_mac'), headers: { 'Authorization' => "Bearer #{@original_key}" }
+      assert_response :bad_request
     end
 
     test 'should not be able to query machines by mac address if api key is wrong' do
@@ -147,12 +146,12 @@ module Api
       end
       user = @machine.user
       user.machines.destroy_all
-
       machine = { name: 'ultron', mac: '66:66:66:66:66:66' }
-      assert_raises CanCan::AccessDenied do
-        post api_machines_url, params: { user_id: user.id, machine: machine },
-                               headers: { 'Authorization' => "Bearer #{@original_key}" }
-      end
+
+      post api_machines_url, params: { user_id: user.id, machine: machine },
+                             headers: { 'Authorization' => "Bearer #{@original_key}" }
+
+      assert_response :forbidden
     ensure
       silence_warnings do
         Object.const_set(:USER_MACHINES_LIMIT, old_value)

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -125,7 +125,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert @admin_ability.can?(:manage, :all)
   end
 
-  test 'shoul be able to read everything with an api key' do
+  test 'should be able to read everything with an api key' do
     assert @api_key_ability.can?(:read, :all)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -40,9 +40,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'email must be of a valid format' do
-    valid_emails = ['users@example.com', 'USER@foo.COM', 'A_US_ER@foo.bar.org', 'first.last@foo.jp', 'alice+bob@baz.cn']
-    invalid_emails = ['user@example,com', 'user_at_foo.org', 'user.name@example',
-                      'foo@bar_baz.com', 'foo@bar+baz.com', 'foo@bar..com', '    ']
+    valid_emails = ['users@example.com', 'USER@foo.COM', 'A_US_ER@foo.bar.org', 'first.last@foo.jp',
+                    'alice+bob@baz.cn', 'user.name@example']
+    invalid_emails = ['user@example,com', 'user_at_foo.org', 'foo@bar_baz.com', 'foo@bar+baz.com', 'foo@bar..com',
+                      '    ']
 
     valid_emails.each do |valid_email|
       @user.email = valid_email
@@ -137,6 +138,10 @@ class UserTest < ActiveSupport::TestCase
     @user.save
     duplicate_user.wifi_password = @user.wifi_password.upcase
     assert_not_predicate duplicate_user, :valid?
+  end
+
+  test 'ntlm_password returns expected md4 hash' do
+    assert_equal '7a21990fcd3d759941e45c490f143d5f', @user.ntlm_password
   end
 
   test 'should create new user from auth hash' do

--- a/test/tasks/sync_accounts_test.rb
+++ b/test/tasks/sync_accounts_test.rb
@@ -50,7 +50,7 @@ class ZitadelStub
     profile: {
       givenName: 'Peter',
       familyName: 'Parker',
-      email: 'peterp@univ'
+      email: 'peterp@univ@'
     }
   }.freeze
 


### PR DESCRIPTION
- Return proper HTTP error codes in the API
- Use standardized email regex
- Load only once openssl to avoid thread issues
- fix off-by-one error on machine API