### PR TITLE
feat: pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ gem 'hexapdf', '~> 1.4.0'
 # Money management [https://github.com/RubyMoney/money-rails]
 gem 'money-rails', '~> 2.0.0'
 
+# Pagination [https://github.com/ddnexus/pagy]
+gem 'pagy', '~> 43.6'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: [:mri, :windows], require: 'debug/prelude'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,10 @@ GEM
       childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)
       rexml (>= 3.3.9)
+    pagy (43.6.1)
+      json
+      uri
+      yaml
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -450,6 +454,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yaml (0.4.0)
     zeitwerk (2.7.3)
 
 PLATFORMS
@@ -474,6 +479,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0)
   omniauth_openid_connect (~> 0.8.0)
   overcommit (~> 0.68)
+  pagy (~> 43.6)
   pg (~> 1.6)
   puma (~> 6.6)
   rack-mini-profiler (~> 4.0)
@@ -591,6 +597,7 @@ CHECKSUMS
   openssl (3.3.0) sha256=ff3a573fc97ab30f69483fddc80029f91669bf36532859bd182d1836f45aee79
   ostruct (0.6.1) sha256=09a3fb7ecc1fa4039f25418cc05ae9c82bd520472c5c6a6f515f03e4988cb817
   overcommit (0.68.0) sha256=bfbcd26388e024e10a3d720f03077bc9389fe7c3beac360263b6c77926bcc8d0
+  pagy (43.6.1) sha256=59fb6a58ea956480094a167b43a86796638ceb3a3917a25ae67973b584ace2eb
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.9.0) sha256=94d6929354b1a6e3e1f89d79d4d302cc8f5aa814431a6c9c7e0623335d7687f2
   pg (1.6.1-x86_64-linux) sha256=6ac0d5c8efafc3f22a7eca2a264300037598fabe27a88e5029bc0e6d90caeb1f
@@ -660,7 +667,8 @@ CHECKSUMS
   websocket-driver (0.7.7) sha256=056d99f2cd545712cfb1291650fde7478e4f2661dc1db6a0fa3b966231a146b4
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
+  yaml (0.4.0) sha256=240e69d1e6ce3584d6085978719a0faa6218ae426e034d8f9b02fb54d3471942
   zeitwerk (2.7.3) sha256=b2e86b4a9b57d26ba68a15230dcc7fe6f040f06831ce64417b0621ad96ba3e85
 
 BUNDLED WITH
-   4.0.3
+  4.0.3

--- a/app/assets/stylesheets/components/_pagination.css
+++ b/app/assets/stylesheets/components/_pagination.css
@@ -1,0 +1,50 @@
+.pagination {
+    margin-top: var(--padding-md);
+}
+
+.pagination .pagy {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: var(--padding-sm);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+}
+
+.pagination a {
+    text-decoration: none;
+    border-radius: var(--rounded-lg);
+    padding: var(--padding-xs) var(--padding-sm);
+    color: var(--primary-600);
+    border: 2px solid transparent;
+}
+
+.pagination a[aria-label] {
+    text-transform: uppercase;
+    letter-spacing: var(--spacing-lg);
+    font-weight: var(--font-bold);
+    border-color: var(--primary-600);
+}
+
+.pagination a[href]:hover {
+    background-color: var(--primary-50);
+}
+
+.pagination a[aria-disabled] {
+    color: var(--gray-500);
+    cursor: not-allowed;
+}
+
+.pagination a[aria-label][aria-disabled] {
+    border-color: var(--gray-500);
+}
+
+.pagination a[aria-current] {
+    background-color: var(--primary-600);
+    color: var(--gray-50);
+}
+
+.pagination a[role="separator"] {
+    cursor: default;
+}

--- a/app/controllers/api/api_application_controller.rb
+++ b/app/controllers/api/api_application_controller.rb
@@ -3,6 +3,9 @@
 module Api
   class ApiApplicationController < ActionController::API
     include ActionController::HttpAuthentication::Token::ControllerMethods
+    include Pagy::Method
+
+    LIMIT_MAX = 999
 
     rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
     rescue_from ActiveRecord::StatementInvalid, with: :render_bad_request
@@ -15,6 +18,15 @@ module Api
     end
 
     private
+
+    def paginate(scope)
+      return scope if params[:page].blank? && params[:limit].blank?
+
+      # Passing :max_limit enables `?limit=`, and it caps what the client can ask for.
+      pagy, records = pagy(scope, max_limit: LIMIT_MAX)
+      response.headers.merge!(pagy.headers_hash)
+      records
+    end
 
     def api_auth
       @current_api_key = authenticate_with_http_token do |token, _options|

--- a/app/controllers/api/api_application_controller.rb
+++ b/app/controllers/api/api_application_controller.rb
@@ -5,11 +5,12 @@ module Api
     include ActionController::HttpAuthentication::Token::ControllerMethods
     include Pagy::Method
 
-    LIMIT_MAX = 999
+    LIMIT_MAX = 200
 
     rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
     rescue_from ActiveRecord::StatementInvalid, with: :render_bad_request
     rescue_from CanCan::AccessDenied, with: :render_forbidden
+    rescue_from Pagy::OptionError, with: :render_bad_request
 
     before_action :api_auth
 

--- a/app/controllers/api/machines_controller.rb
+++ b/app/controllers/api/machines_controller.rb
@@ -9,7 +9,7 @@ module Api
       machines = Machine.accessible_by(current_ability)
                         .includes(:ip, user: [:valid_subscriptions_by_date, :free_accesses_by_date])
                         .order(:id)
-      machines = machines.with_internet_access if ActiveModel::Type::Boolean.new.cast(params[:has_connection_filter])
+      machines = machines.with_internet_access if ActiveModel::Type::Boolean.new.cast(params[:with_internet_access])
 
       @machines = paginate(machines)
     end

--- a/app/controllers/api/machines_controller.rb
+++ b/app/controllers/api/machines_controller.rb
@@ -6,12 +6,12 @@ module Api
     before_action :owner, only: [:create]
 
     def index
-      @machines = Machine.accessible_by(current_ability)
-      return if params[:has_connection].blank?
+      machines = Machine.accessible_by(current_ability)
+                        .includes(:ip, user: [:valid_subscriptions_by_date, :free_accesses_by_date])
+                        .order(:id)
+      machines = machines.with_internet_access if ActiveModel::Type::Boolean.new.cast(params[:has_connection_filter])
 
-      @machines = @machines
-                  .includes(user: [:valid_subscriptions_by_date, :free_accesses_by_date])
-                  .select { |machine| machine.user.internet_access? }
+      @machines = paginate(machines)
     end
 
     def show

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,7 +3,11 @@
 module Api
   class UsersController < ApiApplicationController
     def index
-      @users = User.accessible_by(current_ability).includes(:valid_subscriptions_by_date, :free_accesses_by_date)
+      @users = paginate(
+        User.accessible_by(current_ability)
+            .includes(:room, :valid_subscriptions_by_date, :free_accesses_by_date)
+            .order(:id)
+      )
     end
 
     def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   # Everything else is either not needed or can gracefully degrade in browsers without support.
   # [1]: https://github.com/rails/rails/pull/50505
 
+  include Pagy::Method
   include SessionsHelper
 
   before_action :still_authenticated?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,9 +7,13 @@ class SearchController < ApplicationController
     @query = params[:q]
     return if @query.blank?
 
-    users = User.accessible_by(current_ability).search_by(@query).order(:lastname, :firstname, :id)
+    users = User.accessible_by(current_ability).search_by(@query)
+                .includes(:valid_subscriptions_by_date, :free_accesses_by_date)
+                .order(:lastname, :firstname, :id)
 
-    machines = Machine.accessible_by(current_ability).search_by(@query).order(:name, :id)
+    machines = Machine.accessible_by(current_ability).search_by(@query)
+                      .includes(:ip)
+                      .order(:name, :id)
 
     @pagy_users, @users = pagy(users, page_key: 'users_page')
     @pagy_machines, @machines = pagy(machines, page_key: 'machines_page')

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,22 +1,29 @@
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 class SearchController < ApplicationController
-  VALID_IP_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/i
   def search
     @query = params[:q]
-
     return if @query.blank?
 
-    @users = User.accessible_by(current_ability).left_joins(:room).where(
-      'firstname ILIKE :search OR lastname ILIKE :search OR email ILIKE :search OR rooms.number ILIKE :search',
-      search: "%#{User.sanitize_sql_like @query}%"
-    )
-    @machines = Machine.accessible_by(current_ability).where(
-      'name ILIKE :search OR CAST(mac as varchar) ILIKE :search',
-      search: "%#{Machine.sanitize_sql_like @query}%"
-    )
-    return unless @query.match?(VALID_IP_REGEX)
+    users = User.accessible_by(current_ability).search_by(@query).order(:lastname, :firstname, :id)
 
-    @ip = Ip.accessible_by(current_ability).where(ip: @query).where.not(machine: nil).includes(:machine).first
+    machines = Machine.accessible_by(current_ability).search_by(@query).order(:name, :id)
+
+    @pagy_users, @users = pagy(users, page_key: 'users_page')
+    @pagy_machines, @machines = pagy(machines, page_key: 'machines_page')
+
+    return unless valid_ip?(@query)
+
+    @ip = Ip.accessible_by(current_ability).includes(:machine).where.not(machine_id: nil).find_by(ip: @query)
+  end
+
+  private
+
+  def valid_ip?(string)
+    IPAddr.new(string).ipv4?
+  rescue IPAddr::InvalidAddressError
+    false
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,9 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.accessible_by(current_ability).includes(:room, :valid_subscriptions_by_date, :free_accesses_by_date)
+    @pagy, @users = pagy(User.accessible_by(current_ability)
+                             .includes(:room, :valid_subscriptions_by_date, :free_accesses_by_date)
+                             .order(:lastname, :firstname, :id))
   end
 
   def show

--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -13,6 +13,15 @@ class Machine < ApplicationRecord
                   uniqueness: { unless: ->(machine) { machine.errors.include?(:mac) } }
   validates :ip, presence: true
 
+  scope :with_internet_access, -> { where(user: User.with_internet_access) }
+
+  scope :search_by, lambda { |query|
+    where(
+      'name ILIKE :search OR CAST(mac AS VARCHAR) ILIKE :search',
+      search: "%#{sanitize_sql_like(query)}%"
+    )
+  }
+
   private
 
   def set_ip

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,25 @@ class User < ApplicationRecord
   # @return [Array<String>]
   attr_accessor :groups
 
+  scope :with_internet_access, lambda {
+    now = Time.current
+    with_subscription = User.joins(:subscriptions)
+                            .where(subscriptions: { cancelled_at: nil })
+                            .where('subscriptions.end_at > ?', now)
+                            .select(:id)
+    with_free_access = User.joins(:free_accesses)
+                           .where('free_accesses.end_at > ?', now)
+                           .select(:id)
+    where(id: with_subscription).or(where(id: with_free_access))
+  }
+
+  scope :search_by, lambda { |query|
+    includes(:room).references(:rooms).where(
+      'firstname ILIKE :search OR lastname ILIKE :search OR email ILIKE :search OR rooms.number ILIKE :search',
+      search: "%#{sanitize_sql_like(query)}%"
+    )
+  }
+
   # Customizes the url param
   def to_param
     username

--- a/app/views/components/_pagination.html.erb
+++ b/app/views/components/_pagination.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (pagy:) -%>
+
+<% if pagy.pages > 1 %>
+  <div class="pagination">
+    <%== pagy.series_nav %>
+  </div>
+<% end %>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -7,11 +7,17 @@
         <h2>Results among users:</h2>
     <% end %>
     <%= render partial: "search/user", collection: @users %>
+    <% if @pagy_users %>
+        <%= render 'components/pagination', pagy: @pagy_users %>
+    <% end %>
 
     <% if @machines.present? || @ip.present? %>
         <h2>Results among machines:</h2>
     <% end %>
     <%= render partial: "search/machine", collection: @machines %>
+    <% if @pagy_machines %>
+        <%= render 'components/pagination', pagy: @pagy_machines %>
+    <% end %>
 
     <% if @ip.present? %>
         <%= render partial: "search/machine", locals: {machine: @ip.machine} %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,3 +5,5 @@
 <ul class="users">
   <%= render @users %>
 </ul>
+
+<%= render 'components/pagination', pagy: @pagy %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+Pagy::OPTIONS[:limit] = 20
+Pagy::OPTIONS.freeze

--- a/docs/features/api_authentication.md
+++ b/docs/features/api_authentication.md
@@ -16,7 +16,7 @@ You will get the related json
 - GET /api/users : Get users index
 - GET /api/users/_id_ : Get user with the given id or username
 - GET /api/machines : Get machines index
-- GET /api/machines?has_connection_filter=1 : Filter only machines own by a user with a valid subscription
+- GET /api/machines?with_internet_access=1 : Filter only machines own by a user with a valid subscription
 - GET /api/machines/_id_ : Get machine with the given id or mac address
 - GET /api/api_keys : Get api keys index
 - POST /api/machines data={"user_id": <user_id>, "machine": {"mac":<mac>,"name":<name>}}: Create a machine with given mac and name for user with the given user_id
@@ -33,7 +33,7 @@ Pagination is enabled as soon as a request carries `page` or `limit`:
 - `?page=2&limit=50` : Combine both
 
 `limit` is capped at 200; a larger value is silently reduced to that. Filters are applied before
-paginating, so `GET /api/machines?has_connection_filter=1&limit=50` counts and pages only the machines that
+paginating, so `GET /api/machines?with_internet_access=1&limit=50` counts and pages only the machines that
 match the filter.
 
 Paginated responses carry the page metadata in the headers:

--- a/docs/features/api_authentication.md
+++ b/docs/features/api_authentication.md
@@ -16,27 +16,20 @@ You will get the related json
 - GET /api/users : Get users index
 - GET /api/users/_id_ : Get user with the given id or username
 - GET /api/machines : Get machines index
-- GET /api/machines?with_internet_access=1 : Filter only machines own by a user with a valid subscription
+- GET /api/machines?with_internet_access=true : Filter only machines own by a user with a valid subscription
 - GET /api/machines/_id_ : Get machine with the given id or mac address
 - GET /api/api_keys : Get api keys index
 - POST /api/machines data={"user_id": <user_id>, "machine": {"mac":<mac>,"name":<name>}}: Create a machine with given mac and name for user with the given user_id
 
-## Pagination
+## Pagination (on users and machines index endpoints)
 
-Index endpoints are **not** paginated by default: without any pagination parameter they return the
-whole collection, as they always have.
+Without any pagination parameter, index endpoints return the whole collection.
+Pagination is enabled as soon as a request carries `page` and/or `limit`.
 
-Pagination is enabled as soon as a request carries `page` or `limit`:
+`limit` is capped at 200. Filters are applied before paginating, so `GET /api/machines?with_internet_access=true&limit=50`
+counts and pages only the machines that match the filter.
 
-- `?page=2` : Get the second page, using the server-side default page size
-- `?limit=50` : Get the first 50 records
-- `?page=2&limit=50` : Combine both
-
-`limit` is capped at 200; a larger value is silently reduced to that. Filters are applied before
-paginating, so `GET /api/machines?with_internet_access=1&limit=50` counts and pages only the machines that
-match the filter.
-
-Paginated responses carry the page metadata in the headers:
+Paginated responses carry the page metadata in the headers (see [Pagy docs](https://ddnexus.github.io/pagy/)):
 
 ```
 Link: <http://lea5.fr/api/users?limit=50>; rel="first", <http://lea5.fr/api/users?limit=50&page=3>; rel="next", <http://lea5.fr/api/users?limit=50&page=9>; rel="last"
@@ -45,7 +38,5 @@ Page-Limit: 50
 Total-Pages: 9
 Total-Count: 419
 ```
-
-The backward link uses `rel="previous"` (not `rel="prev"`).
 
 A page number past the end returns `200` with an empty array rather than an error.

--- a/docs/features/api_authentication.md
+++ b/docs/features/api_authentication.md
@@ -16,7 +16,36 @@ You will get the related json
 - GET /api/users : Get users index
 - GET /api/users/_id_ : Get user with the given id or username
 - GET /api/machines : Get machines index
-- GET /api/machines?has_connection=1 : Filter only machines own by a user with a valid subscription
+- GET /api/machines?has_connection_filter=1 : Filter only machines own by a user with a valid subscription
 - GET /api/machines/_id_ : Get machine with the given id or mac address
 - GET /api/api_keys : Get api keys index
 - POST /api/machines data={"user_id": <user_id>, "machine": {"mac":<mac>,"name":<name>}}: Create a machine with given mac and name for user with the given user_id
+
+## Pagination
+
+Index endpoints are **not** paginated by default: without any pagination parameter they return the
+whole collection, as they always have.
+
+Pagination is enabled as soon as a request carries `page` or `limit`:
+
+- `?page=2` : Get the second page, using the server-side default page size
+- `?limit=50` : Get the first 50 records
+- `?page=2&limit=50` : Combine both
+
+`limit` is capped at 200; a larger value is silently reduced to that. Filters are applied before
+paginating, so `GET /api/machines?has_connection_filter=1&limit=50` counts and pages only the machines that
+match the filter.
+
+Paginated responses carry the page metadata in the headers:
+
+```
+Link: <http://lea5.fr/api/users?limit=50>; rel="first", <http://lea5.fr/api/users?limit=50&page=3>; rel="next", <http://lea5.fr/api/users?limit=50&page=9>; rel="last"
+Current-Page: 2
+Page-Limit: 50
+Total-Pages: 9
+Total-Count: 419
+```
+
+The backward link uses `rel="previous"` (not `rel="prev"`).
+
+A page number past the end returns `200` with an empty array rather than an error.

--- a/test/controllers/api/machines_controller_test.rb
+++ b/test/controllers/api/machines_controller_test.rb
@@ -49,7 +49,8 @@ module Api
     end
 
     test 'should be able to read machines with internet access with api key' do
-      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" }, params: { has_connection: '1' }
+      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                             params: { has_connection_filter: '1' }
       assert_response :success
       response_body = response.parsed_body
       assert_equal 1, response_body.size
@@ -156,6 +157,51 @@ module Api
       silence_warnings do
         Object.const_set(:USER_MACHINES_LIMIT, old_value)
       end
+    end
+
+    test 'should not paginate machines index when neither page nor limit is given' do
+      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" }
+      assert_response :success
+      assert_equal Machine.count, response.parsed_body.size
+      assert_nil response.headers['current-page']
+    end
+
+    test 'should paginate machines index when limit is given' do
+      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" }, params: { limit: 2 }
+      assert_response :success
+      assert_equal 2, response.parsed_body.size
+      assert_equal Machine.count.to_s, response.headers['total-count']
+    end
+
+    test 'should filter on internet access before paginating' do
+      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                             params: { has_connection_filter: '1', limit: 10 }
+      assert_response :success
+      assert_equal 1, response.parsed_body.size
+      assert_equal '1', response.headers['total-count']
+      assert_equal @machine2.id, response.parsed_body.first[:id]
+    end
+
+    test 'should count only matching machines when filtering and paginating' do
+      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                             params: { has_connection_filter: '1', limit: 1, page: 1 }
+      assert_response :success
+      assert_equal [@machine2.id], response.parsed_body.pluck(:id)
+      assert_equal '1', response.headers['total-pages']
+    end
+
+    test 'should keep has_connection_filter in the link header' do
+      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                             params: { has_connection_filter: '1', limit: 1 }
+
+      assert_match(/has_connection_filter=1/, response.headers['link'])
+    end
+
+    test 'should not filter when has_connection_filter is 0' do
+      get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                             params: { has_connection_filter: '0' }
+      assert_response :success
+      assert_equal Machine.count, response.parsed_body.size
     end
   end
 end

--- a/test/controllers/api/machines_controller_test.rb
+++ b/test/controllers/api/machines_controller_test.rb
@@ -50,7 +50,7 @@ module Api
 
     test 'should be able to read machines with internet access with api key' do
       get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
-                             params: { has_connection_filter: '1' }
+                             params: { with_internet_access: '1' }
       assert_response :success
       response_body = response.parsed_body
       assert_equal 1, response_body.size
@@ -175,7 +175,7 @@ module Api
 
     test 'should filter on internet access before paginating' do
       get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
-                             params: { has_connection_filter: '1', limit: 10 }
+                             params: { with_internet_access: '1', limit: 10 }
       assert_response :success
       assert_equal 1, response.parsed_body.size
       assert_equal '1', response.headers['total-count']
@@ -184,22 +184,22 @@ module Api
 
     test 'should count only matching machines when filtering and paginating' do
       get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
-                             params: { has_connection_filter: '1', limit: 1, page: 1 }
+                             params: { with_internet_access: '1', limit: 1, page: 1 }
       assert_response :success
       assert_equal [@machine2.id], response.parsed_body.pluck(:id)
       assert_equal '1', response.headers['total-pages']
     end
 
-    test 'should keep has_connection_filter in the link header' do
+    test 'should keep with_internet_access in the link header' do
       get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
-                             params: { has_connection_filter: '1', limit: 1 }
+                             params: { with_internet_access: '1', limit: 1 }
 
-      assert_match(/has_connection_filter=1/, response.headers['link'])
+      assert_match(/with_internet_access=1/, response.headers['link'])
     end
 
-    test 'should not filter when has_connection_filter is 0' do
+    test 'should not filter when with_internet_access is 0' do
       get api_machines_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
-                             params: { has_connection_filter: '0' }
+                             params: { with_internet_access: '0' }
       assert_response :success
       assert_equal Machine.count, response.parsed_body.size
     end

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -62,5 +62,80 @@ module Api
       get api_user_path(@user_with_dot.username), headers: { 'Authorization' => "Bearer #{@original_key}" }
       assert_response :success
     end
+
+    test 'should not paginate users index when neither page nor limit is given' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" }
+      assert_response :success
+      assert_equal User.count, response.parsed_body.size
+      assert_nil response.headers['current-page']
+      assert_nil response.headers['link']
+    end
+
+    test 'should paginate users index when limit is given' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" }, params: { limit: 2 }
+      assert_response :success
+      assert_equal 2, response.parsed_body.size
+      assert_equal '1', response.headers['current-page']
+      assert_equal '2', response.headers['page-limit']
+      assert_equal User.count.to_s, response.headers['total-count']
+      assert_equal '2', response.headers['total-pages']
+    end
+
+    test 'should paginate users index when only page is given' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" }, params: { page: 1 }
+      assert_response :success
+      assert_equal [User.count, Pagy::OPTIONS[:limit]].min, response.parsed_body.size
+      assert_equal '1', response.headers['current-page']
+    end
+
+    test 'should return the remaining users on the last page' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                          params: { limit: 2, page: 2 }
+      assert_response :success
+      assert_equal User.count - 2, response.parsed_body.size
+      assert_equal '2', response.headers['current-page']
+    end
+
+    test 'should not repeat users across API pages' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                          params: { limit: 2, page: 1 }
+      first_page = response.parsed_body.pluck(:id)
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                          params: { limit: 2, page: 2 }
+      second_page = response.parsed_body.pluck(:id)
+
+      assert_empty first_page & second_page
+      assert_equal User.count, (first_page + second_page).uniq.size
+    end
+
+    test 'should expose RFC-8288 link headers' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" }, params: { limit: 2 }
+      link = response.headers['link']
+
+      assert_match(/rel="first"/, link)
+      assert_match(/rel="next"/, link)
+      assert_match(/rel="last"/, link)
+      assert_no_match(/rel="previous"/, link)
+      assert_match(/limit=2/, link)
+    end
+
+    test 'should expose a previous link from the second page on' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" },
+                          params: { limit: 2, page: 2 }
+
+      assert_match(/rel="previous"/, response.headers['link'])
+    end
+
+    test 'should cap a client requested limit to LIMIT_MAX' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" }, params: { limit: 10_000 }
+      assert_response :success
+      assert_equal ApiApplicationController::LIMIT_MAX.to_s, response.headers['page-limit']
+    end
+
+    test 'should return an empty page for an out of range page number' do
+      get api_users_path, headers: { 'Authorization' => "Bearer #{@original_key}" }, params: { page: 9999 }
+      assert_response :success
+      assert_empty response.parsed_body
+    end
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -94,4 +94,57 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_dom '.machine-search', { count: 1, text: /.*#{Regexp.escape(query)}.*/ }
     end
   end
+
+  test 'should paginate user results' do
+    limit = Pagy::OPTIONS[:limit]
+    # Two full pages plus a partial one, whatever the configured limit is.
+    create_matching_users((limit * 2) + 1)
+
+    get search_path, params: { q: 'Paginated' }
+    assert_dom '.user', count: limit
+
+    get search_path, params: { q: 'Paginated', users_page: 3 }
+    assert_dom '.user', count: 1
+  end
+
+  test 'should paginate each result list independently' do
+    limit = Pagy::OPTIONS[:limit]
+    create_matching_users((limit * 2) + 1)
+
+    # Paging the users list must not affect the machines list, and vice versa.
+    get search_path, params: { q: 'Paginated', users_page: 3 }
+    assert_response :success
+    assert_dom '.user', count: 1
+
+    get search_path, params: { q: 'Paginated', machines_page: 2 }
+    assert_response :success
+    assert_dom '.user', count: limit
+  end
+
+  test 'should keep the query when linking to another page' do
+    create_matching_users((Pagy::OPTIONS[:limit] * 2) + 1)
+
+    get search_path, params: { q: 'Paginated' }
+    assert_dom '.pagination a[href*=?]', 'q=Paginated'
+    assert_dom '.pagination a[href*=?]', 'users_page='
+  end
+
+  test 'should not paginate search results that fit on a single page' do
+    get search_path, params: { q: 'Tony' }
+    assert_dom '.pagination', count: 0
+  end
+
+  private
+
+  def create_matching_users(count)
+    count.times do |i|
+      User.create!(
+        firstname: 'Search',
+        lastname: format('Paginated%03d', i),
+        email: "search#{i}@paginated.com",
+        username: "search-#{i}",
+        wifi_password: 'password'
+      )
+    end
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -82,4 +82,59 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to users_url
   end
+
+  test 'should paginate index' do
+    limit = Pagy::OPTIONS[:limit]
+    # Two full pages plus a partial one, whatever the configured limit is.
+    create_extra_users((limit * 2) + 1 - User.count)
+
+    get users_path
+    assert_dom '.user', count: limit
+    assert_dom '.pagination'
+
+    get users_path, params: { page: 2 }
+    assert_dom '.user', count: limit
+
+    get users_path, params: { page: 3 }
+    assert_dom '.user', count: 1
+  end
+
+  test 'should not paginate index when results fit on a single page' do
+    User.where.not(id: @admin.id).find_each(&:destroy)
+
+    get users_path
+    assert_dom '.user', count: 1
+    assert_dom '.pagination', count: 0
+  end
+
+  test 'should render an empty page for an out of range page number' do
+    get users_path, params: { page: 9999 }
+    assert_response :success
+    assert_dom '.user', count: 0
+  end
+
+  test 'should not repeat users across pages' do
+    create_extra_users(Pagy::OPTIONS[:limit] * 2)
+
+    get users_path
+    first_page = css_select('.user').map(&:to_s)
+    get users_path, params: { page: 2 }
+    second_page = css_select('.user').map(&:to_s)
+
+    assert_empty first_page & second_page
+  end
+
+  private
+
+  def create_extra_users(count)
+    count.times do |i|
+      User.create!(
+        firstname: "Extra#{i}",
+        lastname: format('Paginated%03d', i),
+        email: "extra#{i}@paginated.com",
+        username: "extra-#{i}",
+        wifi_password: 'password'
+      )
+    end
+  end
 end

--- a/test/models/machine_test.rb
+++ b/test/models/machine_test.rb
@@ -106,4 +106,19 @@ class MachineTest < ActiveSupport::TestCase
     @machine.destroy
     assert_nil ip.machine_id
   end
+
+  test 'with_internet_access selects the machines whose owner has internet access' do
+    expected = Machine.all.to_a.select { |machine| machine.user.internet_access? }.map(&:id).sort
+
+    assert_equal expected, Machine.with_internet_access.pluck(:id).sort
+  end
+
+  test 'with_internet_access follows the owner losing access' do
+    machine = machines(:ultron)
+    assert_includes Machine.with_internet_access, machine
+
+    subscriptions(:subscription3).update!(cancelled_at: Time.current)
+
+    assert_not_includes Machine.with_internet_access, machine
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -357,4 +357,60 @@ class UserTest < ActiveSupport::TestCase
 
     assert_nil @user.internet_expiration
   end
+
+  test 'with_internet_access matches internet_access? with only expired fixtures' do
+    subscriptions(:subscription3).update!(start_at: 2.years.ago, end_at: 1.year.ago)
+
+    assert_empty User.with_internet_access
+    assert_internet_access_parity
+  end
+
+  test 'with_internet_access includes a user with a live subscription' do
+    assert_includes User.with_internet_access, users(:spiderman)
+    assert_internet_access_parity
+  end
+
+  test 'with_internet_access excludes a user whose live subscription is cancelled' do
+    subscriptions(:subscription3).update!(cancelled_at: Time.current)
+
+    assert_not_includes User.with_internet_access, users(:spiderman)
+    assert_internet_access_parity
+  end
+
+  test 'with_internet_access includes a user with only a live free access' do
+    free_accesses(:one).update!(end_at: 1.year.from_now)
+
+    assert_includes User.with_internet_access, @user
+    assert_internet_access_parity
+  end
+
+  test 'with_internet_access includes a user with a live free access and a cancelled subscription' do
+    subscriptions(:subscription1).update!(end_at: 1.year.from_now, cancelled_at: Time.current)
+    free_accesses(:one).update!(end_at: 1.year.from_now)
+
+    assert_includes User.with_internet_access, @user
+    assert_internet_access_parity
+  end
+
+  test 'with_internet_access excludes a user whose subscription and free access have both expired' do
+    assert_not_includes User.with_internet_access, @user
+    assert_internet_access_parity
+  end
+
+  test 'with_internet_access treats an expiration in the past second as expired' do
+    subscriptions(:subscription1).update!(end_at: 1.second.ago)
+
+    assert_not_includes User.with_internet_access, @user
+    assert_internet_access_parity
+  end
+
+  private
+
+  # Assert the SQL scope selects exactly the users that the Ruby predicate accepts.
+  def assert_internet_access_parity
+    expected = User.all.to_a.select(&:internet_access?).map(&:id).sort
+    actual = User.with_internet_access.pluck(:id).sort
+
+    assert_equal expected, actual, 'with_internet_access disagrees with internet_access?'
+  end
 end


### PR DESCRIPTION
- Add pagination to user and machines routes
- Clean search
- Closes #557 

(small) BREAKING CHANGE: `has_connection` -> `with_internet_access` to match the internal naming.