### PR TITLE
feat: improve SQL loading on profile page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,18 +2,20 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.accessible_by(current_ability)
+    @users = User.accessible_by(current_ability).includes(:room, :valid_subscriptions_by_date, :free_accesses_by_date)
   end
 
   def show
-    @user = User.find_by!(username: params[:username])
+    @user = User.includes(:room, :sales_as_client, :valid_subscriptions_by_date,
+                          :free_accesses_by_date).find_by!(username: params[:username])
     authorize! :show, @user
-    @machines = @user.machines.includes(:ip).order(created_at: :asc)
-    @subscriptions = @user.subscriptions.order(created_at: :desc)
-    @free_accesses = @user.free_accesses.order(created_at: :desc)
+    @machines = @user.machines.includes(:ip).order(created_at: :asc).load
+    @subscriptions = @user.subscriptions.order(created_at: :desc).load
+    @free_accesses = @user.free_accesses_by_date.load
     @sales = @user.sales_as_client
+                  .includes(:articles, :subscription, :subscription_offers, :invoice, :payment_method)
                   .includes(refunds: [:invoice, { articles_refunds: :article }])
-                  .order(created_at: :desc)
+                  .order(created_at: :desc).load
   end
 
   def new


### PR DESCRIPTION
From ~100ms (54 SQL queries including 16 cached) to ~40ms (15 SQL queries) Measured roughly with `hyperfine "curl 'http://127.0.0.1:3000/users/nymous' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' -H 'Cookie: _lea5_session=<big session cookie>'"` SQL query count is retrieved in the Rails logs or with the Miniprofiler overlay